### PR TITLE
Further changes to modernise the code base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ clean:
 	rm -f $(TESTS)
 	rm -f *.o
 
+check: all run-tests
+	./run-tests
+
 gitignore: Makefile
 	( echo "*~" ; \
 	  echo "*.o" ; \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 CC ?= gcc
 PKGCONFIG = $(shell which pkg-config)
+DEBUG_CFLAGS = \
+	-Wall \
+	-Wstrict-prototypes \
+	-Werror=missing-prototypes \
+	-Werror=implicit-function-declaration \
+	-Werror=init-self \
+	-Werror=format-security -Werror=format=2
 CFLAGS = $(shell $(PKGCONFIG) --cflags gio-2.0)
 LIBS = $(shell $(PKGCONFIG) --libs gio-2.0)
 LIBXML2_CFLAGS = $(shell $(PKGCONFIG) --cflags libxml-2.0)
@@ -42,7 +49,7 @@ gitignore: Makefile
 PHONY = gitignore
 
 %.o: %.c
-	$(CC) -c -o $(@F) $(CFLAGS) $<
+	$(CC) -c -o $(@F) $(DEBUG_CFLAGS) $(CFLAGS) $<
 
 test-axing-parser-async: Makefile $(OBJS) test-axing-parser-async.o
 	$(CC) -o $(@F) $(LIBS) $(OBJS) $(addsuffix .o,$(@F))

--- a/axing-dtd-schema.c
+++ b/axing-dtd-schema.c
@@ -55,28 +55,26 @@ static void      axing_dtd_schema_class_init    (AxingDtdSchemaClass  *klass);
 static void      axing_dtd_schema_dispose       (GObject              *object);
 static void      axing_dtd_schema_finalize      (GObject              *object);
 
-G_DEFINE_TYPE (AxingDtdSchema, axing_dtd_schema, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (AxingDtdSchema, axing_dtd_schema, G_TYPE_OBJECT)
 
 static void
 axing_dtd_schema_init (AxingDtdSchema *dtd)
 {
-    dtd->priv = G_TYPE_INSTANCE_GET_PRIVATE (dtd, AXING_TYPE_DTD_SCHEMA,
-                                             AxingDtdSchemaPrivate);
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
+
     /* Use data->name as key, owned by data, so no key_destroy_func */
-    dtd->priv->general_entities = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
-                                                         (GDestroyNotify) entity_data_free);
-    dtd->priv->parameter_entities = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
-                                                         (GDestroyNotify) entity_data_free);
-    dtd->priv->notations = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
-                                                  (GDestroyNotify) entity_data_free);
+    priv->general_entities = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
+                                                    (GDestroyNotify) entity_data_free);
+    priv->parameter_entities = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
+                                                      (GDestroyNotify) entity_data_free);
+    priv->notations = g_hash_table_new_full (g_str_hash, g_str_equal, NULL,
+                                             (GDestroyNotify) entity_data_free);
 }
 
 static void
 axing_dtd_schema_class_init (AxingDtdSchemaClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (AxingDtdSchemaPrivate));
 
     object_class->dispose = axing_dtd_schema_dispose;
     object_class->finalize = axing_dtd_schema_finalize;
@@ -92,12 +90,16 @@ static void
 axing_dtd_schema_finalize (GObject *object)
 {
     AxingDtdSchema *dtd = AXING_DTD_SCHEMA (object);
-    g_free (dtd->priv->doctype);
-    g_free (dtd->priv->public);
-    g_free (dtd->priv->system);
-    g_hash_table_destroy (dtd->priv->general_entities);
-    g_hash_table_destroy (dtd->priv->parameter_entities);
-    g_hash_table_destroy (dtd->priv->notations);
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
+
+    g_free (priv->doctype);
+    g_free (priv->public);
+    g_free (priv->system);
+
+    g_hash_table_destroy (priv->general_entities);
+    g_hash_table_destroy (priv->parameter_entities);
+    g_hash_table_destroy (priv->notations);
+
     G_OBJECT_CLASS (axing_dtd_schema_parent_class)->finalize (object);
 }
 
@@ -111,30 +113,36 @@ void
 axing_dtd_schema_set_doctype (AxingDtdSchema *dtd,
                               const char     *doctype)
 {
-    g_return_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd));
-    if (dtd->priv->doctype)
-        g_free (dtd->priv->doctype);
-    dtd->priv->doctype = g_strdup (doctype);
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
+
+    g_return_if_fail (AXING_IS_DTD_SCHEMA (dtd));
+
+    g_free (priv->doctype);
+    priv->doctype = g_strdup (doctype);
 }
 
 void
 axing_dtd_schema_set_public_id (AxingDtdSchema *dtd,
                                 const char     *public)
 {
-    g_return_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd));
-    if (dtd->priv->public)
-        g_free (dtd->priv->public);
-    dtd->priv->public = g_strdup (public);
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
+
+    g_return_if_fail (AXING_IS_DTD_SCHEMA (dtd));
+
+    g_free (priv->public);
+    priv->public = g_strdup (public);
 }
 
 void
 axing_dtd_schema_set_system_id (AxingDtdSchema *dtd,
                                 const char     *system)
 {
-    g_return_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd));
-    if (dtd->priv->system)
-        g_free (dtd->priv->system);
-    dtd->priv->system = g_strdup (system);
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
+
+    g_return_if_fail (AXING_IS_DTD_SCHEMA (dtd));
+
+    g_free (priv->system);
+    priv->system = g_strdup (system);
 }
 
 gboolean
@@ -143,7 +151,7 @@ axing_dtd_schema_add_element (AxingDtdSchema *dtd,
                               const char     *content,
                               GError        **error)
 {
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
     /* FIXME */
     return FALSE;
 }
@@ -154,7 +162,7 @@ axing_dtd_schema_add_attlist (AxingDtdSchema *dtd,
                               const char     *attlist,
                               GError        **error)
 {
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
     /* FIXME */
     return FALSE;
 }
@@ -165,18 +173,19 @@ axing_dtd_schema_add_entity (AxingDtdSchema *dtd,
                              const char     *name,
                              const char     *value)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    if (g_hash_table_lookup (dtd->priv->general_entities, name))
+    if (g_hash_table_lookup (priv->general_entities, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
     data->name = g_strdup (name);
     data->value = g_strdup (value);
 
-    g_hash_table_insert (dtd->priv->general_entities, data->name, data);
+    g_hash_table_insert (priv->general_entities, data->name, data);
     return TRUE;
 }
 
@@ -186,11 +195,12 @@ axing_dtd_schema_add_external_entity (AxingDtdSchema *dtd,
                                       const char     *public,
                                       const char     *system)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    if (g_hash_table_lookup (dtd->priv->general_entities, name))
+    if (g_hash_table_lookup (priv->general_entities, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
@@ -198,7 +208,7 @@ axing_dtd_schema_add_external_entity (AxingDtdSchema *dtd,
     data->public = g_strdup (public);
     data->system = g_strdup (system);
 
-    g_hash_table_insert (dtd->priv->general_entities, data->name, data);
+    g_hash_table_insert (priv->general_entities, data->name, data);
     return TRUE;
 }
 
@@ -209,11 +219,12 @@ axing_dtd_schema_add_unparsed_entity (AxingDtdSchema *dtd,
                                       const char     *system,
                                       const char     *ndata)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    if (g_hash_table_lookup (dtd->priv->general_entities, name))
+    if (g_hash_table_lookup (priv->general_entities, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
@@ -222,7 +233,7 @@ axing_dtd_schema_add_unparsed_entity (AxingDtdSchema *dtd,
     data->system = g_strdup (system);
     data->ndata = g_strdup (ndata);
 
-    g_hash_table_insert (dtd->priv->general_entities, data->name, data);
+    g_hash_table_insert (priv->general_entities, data->name, data);
     return TRUE;
 }
 
@@ -231,18 +242,19 @@ axing_dtd_schema_add_parameter (AxingDtdSchema *dtd,
                                 const char     *name,
                                 const char     *value)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    if (g_hash_table_lookup (dtd->priv->parameter_entities, name))
+    if (g_hash_table_lookup (priv->parameter_entities, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
     data->name = g_strdup (name);
     data->value = g_strdup (value);
 
-    g_hash_table_insert (dtd->priv->parameter_entities, data->name, data);
+    g_hash_table_insert (priv->parameter_entities, data->name, data);
     return TRUE;
 }
 
@@ -252,11 +264,12 @@ axing_dtd_schema_add_external_parameter (AxingDtdSchema *dtd,
                                          const char     *public,
                                          const char     *system)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    if (g_hash_table_lookup (dtd->priv->parameter_entities, name))
+    if (g_hash_table_lookup (priv->parameter_entities, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
@@ -264,7 +277,7 @@ axing_dtd_schema_add_external_parameter (AxingDtdSchema *dtd,
     data->public = g_strdup (public);
     data->system = g_strdup (system);
 
-    g_hash_table_insert (dtd->priv->parameter_entities, data->name, data);
+    g_hash_table_insert (priv->parameter_entities, data->name, data);
     return TRUE;
 }
 
@@ -274,16 +287,17 @@ axing_dtd_schema_add_notation (AxingDtdSchema *dtd,
                                const char     *public,
                                const char     *system)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
     /* FIXME: Unlike with other declarations, redefining a NOTATION
        is a validity error. We cannot error out here, because this
        function is called where we only care about well-formedness.
        Possibly store this dup for later calls to validate().
     */
-    if (g_hash_table_lookup (dtd->priv->notations, name))
+    if (g_hash_table_lookup (priv->notations, name))
         return FALSE;
 
     data = g_new0 (EntityData, 1);
@@ -291,7 +305,7 @@ axing_dtd_schema_add_notation (AxingDtdSchema *dtd,
     data->public = g_strdup (public);
     data->system = g_strdup (system);
 
-    g_hash_table_insert (dtd->priv->notations, data->name, data);
+    g_hash_table_insert (priv->notations, data->name, data);
     return TRUE;
 }
 
@@ -299,11 +313,12 @@ char *
 axing_dtd_schema_get_entity (AxingDtdSchema *dtd,
                              const char     *name)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), NULL);
 
-    data = (EntityData *) g_hash_table_lookup (dtd->priv->general_entities, name);
+    data = g_hash_table_lookup (priv->general_entities, name);
 
     if (data == NULL)
         return NULL;
@@ -315,11 +330,12 @@ char *
 axing_dtd_schema_get_external_entity (AxingDtdSchema *dtd,
                                       const char     *name)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), NULL);
 
-    data = (EntityData *) g_hash_table_lookup (dtd->priv->general_entities, name);
+    data = g_hash_table_lookup (priv->general_entities, name);
 
     if (data == NULL)
         return NULL;
@@ -334,11 +350,12 @@ char *
 axing_dtd_schema_get_unparsed_entity (AxingDtdSchema *dtd,
                                       const char     *name)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), NULL);
 
-    data = (EntityData *) g_hash_table_lookup (dtd->priv->general_entities, name);
+    data = g_hash_table_lookup (priv->general_entities, name);
 
     if (data == NULL)
         return NULL;
@@ -357,11 +374,12 @@ axing_dtd_schema_get_entity_full (AxingDtdSchema  *dtd,
                                   char           **system,
                                   char           **ndata)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), FALSE);
 
-    data = (EntityData *) g_hash_table_lookup (dtd->priv->general_entities, name);
+    data = g_hash_table_lookup (priv->general_entities, name);
 
     if (data == NULL)
         return FALSE;
@@ -378,11 +396,12 @@ char *
 axing_dtd_schema_get_parameter (AxingDtdSchema *dtd,
                                 const char     *name)
 {
+    AxingDtdSchemaPrivate *priv = axing_dtd_schema_get_instance_private (dtd);
     EntityData *data;
 
-    g_return_val_if_fail (dtd && AXING_IS_DTD_SCHEMA (dtd), FALSE);
+    g_return_val_if_fail (AXING_IS_DTD_SCHEMA (dtd), NULL);
 
-    data = (EntityData *) g_hash_table_lookup (dtd->priv->parameter_entities, name);
+    data = g_hash_table_lookup (priv->parameter_entities, name);
 
     if (data == NULL)
         return NULL;

--- a/axing-dtd-schema.c
+++ b/axing-dtd-schema.c
@@ -22,14 +22,14 @@
 
 #include "axing-dtd-schema.h"
 
-struct _AxingDtdSchemaPrivate {
+typedef struct {
     char *doctype;
     char *public;
     char *system;
     GHashTable *general_entities;
     GHashTable *parameter_entities;
     GHashTable *notations;
-};
+} AxingDtdSchemaPrivate;
 
 typedef struct {
     char *name;

--- a/axing-dtd-schema.h
+++ b/axing-dtd-schema.h
@@ -46,9 +46,6 @@ typedef struct _AxingDtdSchemaClass   AxingDtdSchemaClass;
 
 struct _AxingDtdSchema {
     GObject parent;
-
-    /*< private >*/
-    AxingDtdSchemaPrivate *priv;
 };
 
 struct _AxingDtdSchemaClass {

--- a/axing-dtd-schema.h
+++ b/axing-dtd-schema.h
@@ -20,8 +20,8 @@
  * Author: Shaun McCance  <shaunm@gnome.org>
  */
 
-#ifndef __AXI_DTD_SCHEMA_H__
-#define __AXI_DTD_SCHEMA_H__
+#ifndef __AXING_DTD_SCHEMA_H__
+#define __AXING_DTD_SCHEMA_H__
 
 #include <glib-object.h>
 #include <gio/gio.h>
@@ -31,22 +31,10 @@
 
 G_BEGIN_DECLS
 
-#define AXING_TYPE_DTD_SCHEMA            (axing_dtd_schema_get_type ())
-#define AXING_DTD_SCHEMA(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_DTD_SCHEMA, AxingDtdSchema))
-#define AXING_DTD_SCHEMA_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_DTD_SCHEMA, AxingDtdSchemaClass))
-#define AXING_IS_DTD_SCHEMA(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_DTD_SCHEMA))
-#define AXING_IS_DTD_SCHEMA_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_DTD_SCHEMA))
-#define AXING_DTD_SCHEMA_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_DTD_SCHEMA, AxingDtdSchemaClass))
+#define AXING_TYPE_DTD_SCHEMA   (axing_dtd_schema_get_type ())
+#define AXING_DTD_SCHEMA_ERROR  (axing_dtd_schema_error_quark ())
 
-#define AXING_DTD_SCHEMA_ERROR axing_dtd_schema_error_quark()
-
-typedef struct _AxingDtdSchema        AxingDtdSchema;
-typedef struct _AxingDtdSchemaPrivate AxingDtdSchemaPrivate;
-typedef struct _AxingDtdSchemaClass   AxingDtdSchemaClass;
-
-struct _AxingDtdSchema {
-    GObject parent;
-};
+G_DECLARE_DERIVABLE_TYPE (AxingDtdSchema, axing_dtd_schema, AXING, DTD_SCHEMA, GObject)
 
 struct _AxingDtdSchemaClass {
     GObjectClass parent_class;
@@ -64,10 +52,9 @@ typedef enum {
     AXING_DTD_SCHEMA_ERROR_OTHER
 } AxingDtdSchemaError;
 
-GType             axing_dtd_schema_get_type        (void);
-GQuark            axing_dtd_schema_error_quark     (void);
+GQuark            axing_dtd_schema_error_quark              (void);
 
-AxingDtdSchema *  axing_dtd_schema_new             (void);
+AxingDtdSchema *  axing_dtd_schema_new                      (void);
 
 void              axing_dtd_schema_set_doctype              (AxingDtdSchema   *dtd,
                                                              const char       *doctype);

--- a/axing-namespace-map.c
+++ b/axing-namespace-map.c
@@ -22,7 +22,7 @@
 
 #include "axing-namespace-map.h"
 
-G_DEFINE_INTERFACE (AxingNamespaceMap, axing_namespace_map, G_TYPE_OBJECT);
+G_DEFINE_INTERFACE (AxingNamespaceMap, axing_namespace_map, G_TYPE_OBJECT)
 
 static void
 axing_namespace_map_default_init (AxingNamespaceMapInterface *iface)

--- a/axing-resolver.c
+++ b/axing-resolver.c
@@ -23,35 +23,38 @@
 #include "axing-resolver.h"
 #include "axing-simple-resolver.h"
 
-struct _AxingResolverPrivate {
-    gpointer reserved;
-};
-
 static void      axing_resolver_init          (AxingResolver       *resolver);
 static void      axing_resolver_class_init    (AxingResolverClass  *klass);
 
-G_DEFINE_TYPE (AxingResolver, axing_resolver, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE (AxingResolver, axing_resolver, G_TYPE_OBJECT)
 
 static void
 axing_resolver_init (AxingResolver *resolver)
 {
-    resolver->priv = G_TYPE_INSTANCE_GET_PRIVATE (resolver, AXING_TYPE_RESOLVER,
-                                                  AxingResolverPrivate);
 }
 
 static void
 axing_resolver_class_init (AxingResolverClass *klass)
 {
-    g_type_class_add_private (klass, sizeof (AxingResolverPrivate));
 }
 
-static AxingResolver *default_resolver;
-
+/**
+ * axing_resolver_get_default:
+ *
+ * Retrieves the default #AxingResolver.
+ *
+ * Returns: (transfer full): the default #AxingResolver
+ */
 AxingResolver *
 axing_resolver_get_default (void)
 {
-    if (!default_resolver)
-        default_resolver = axing_simple_resolver_new ();
+    static AxingResolver *default_resolver;
+
+    if (g_once_init_enter (&default_resolver)) {
+        AxingResolver *resolver = axing_simple_resolver_new ();
+
+        g_once_init_leave (&default_resolver, resolver);
+    }
 
     return g_object_ref (default_resolver);
 }

--- a/axing-resolver.h
+++ b/axing-resolver.h
@@ -29,24 +29,11 @@
 G_BEGIN_DECLS
 
 #define AXING_TYPE_RESOLVER            (axing_resolver_get_type ())
-#define AXING_RESOLVER(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_RESOLVER, AxingResolver))
-#define AXING_RESOLVER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_RESOLVER, AxingResolverClass))
-#define AXING_IS_RESOLVER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_RESOLVER))
-#define AXING_IS_RESOLVER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_RESOLVER))
-#define AXING_RESOLVER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_RESOLVER, AxingResolverClass))
 
-typedef struct _AxingResolver         AxingResolver;
-typedef struct _AxingResolverPrivate  AxingResolverPrivate;
-typedef struct _AxingResolverClass    AxingResolverClass;
-
-struct _AxingResolver {
-    GObject parent;
-
-    /*< private >*/
-    AxingResolverPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE (AxingResolver, axing_resolver, AXING, RESOLVER, GObject)
 
 struct _AxingResolverClass {
+    /*< private >*/
     GObjectClass parent_class;
 
     /*< public >*/
@@ -78,8 +65,6 @@ struct _AxingResolverClass {
     void (*_axing_reserved4) (void);
     void (*_axing_reserved5) (void);
 };
-
-GType            axing_resolver_get_type         (void);
 
 AxingResolver *  axing_resolver_get_default      (void);
 

--- a/axing-resource.c
+++ b/axing-resource.c
@@ -32,7 +32,6 @@ struct _AxingResourcePrivate {
 static void      axing_resource_init          (AxingResource       *resource);
 static void      axing_resource_class_init    (AxingResourceClass  *klass);
 static void      axing_resource_dispose       (GObject           *object);
-static void      axing_resource_finalize      (GObject           *object);
 static void      axing_resource_get_property  (GObject           *object,
                                                guint              prop_id,
                                                GValue            *value,

--- a/axing-resource.c
+++ b/axing-resource.c
@@ -23,11 +23,11 @@
 #include "axing-resource.h"
 #include "axing-private.h"
 
-struct _AxingResourcePrivate {
+typedef struct {
     GFile *file;
     GInputStream *input;
     GSimpleAsyncResult *result;
-};
+} AxingResourcePrivate;
 
 static void      axing_resource_init          (AxingResource       *resource);
 static void      axing_resource_class_init    (AxingResourceClass  *klass);
@@ -48,21 +48,17 @@ enum {
     N_PROPS
 };
 
-G_DEFINE_TYPE (AxingResource, axing_resource, G_TYPE_OBJECT);
+G_DEFINE_TYPE_WITH_PRIVATE (AxingResource, axing_resource, G_TYPE_OBJECT)
 
 static void
 axing_resource_init (AxingResource *resource)
 {
-    resource->priv = G_TYPE_INSTANCE_GET_PRIVATE (resource, AXING_TYPE_RESOURCE,
-                                                  AxingResourcePrivate);
 }
 
 static void
 axing_resource_class_init (AxingResourceClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (AxingResourcePrivate));
 
     object_class->get_property = axing_resource_get_property;
     object_class->set_property = axing_resource_set_property;
@@ -89,18 +85,12 @@ static void
 axing_resource_dispose (GObject *object)
 {
     AxingResource *resource = AXING_RESOURCE (object);
-    if (resource->priv->file) {
-        g_object_unref (resource->priv->file);
-        resource->priv->file = NULL;
-    }
-    if (resource->priv->input) {
-        g_object_unref (resource->priv->input);
-        resource->priv->input = NULL;
-    }
-    if (resource->priv->result) {
-        g_object_unref (resource->priv->result);
-        resource->priv->result = NULL;
-    }
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
+    g_clear_object (&priv->file);
+    g_clear_object (&priv->input);
+    g_clear_object (&priv->result);
+
     G_OBJECT_CLASS (axing_resource_parent_class)->dispose (object);
 }
 
@@ -111,12 +101,14 @@ axing_resource_get_property (GObject    *object,
                              GParamSpec *pspec)
 {
     AxingResource *resource = AXING_RESOURCE (object);
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
     switch (prop_id) {
     case PROP_FILE:
-        g_value_set_object (value, resource->priv->file);
+        g_value_set_object (value, priv->file);
         break;
     case PROP_STREAM:
-        g_value_set_object (value, resource->priv->input);
+        g_value_set_object (value, priv->input);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -130,16 +122,14 @@ axing_resource_set_property (GObject      *object,
                            GParamSpec   *pspec)
 {
     AxingResource *resource = AXING_RESOURCE (object);
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
     switch (prop_id) {
     case PROP_FILE:
-        if (resource->priv->file)
-            g_object_unref (resource->priv->file);
-        resource->priv->file = G_FILE (g_value_dup_object (value));
+        priv->file = G_FILE (g_value_dup_object (value));
         break;
     case PROP_STREAM:
-        if (resource->priv->input)
-            g_object_unref (resource->priv->input);
-        resource->priv->input = G_INPUT_STREAM (g_value_dup_object (value));
+        priv->input = G_INPUT_STREAM (g_value_dup_object (value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -150,7 +140,9 @@ AxingResource *
 axing_resource_new (GFile        *file,
                     GInputStream *stream)
 {
-    g_return_val_if_fail (file != NULL || stream != NULL, NULL);
+    g_return_val_if_fail (file == NULL || G_IS_FILE (file), NULL);
+    g_return_val_if_fail (stream == NULL || G_IS_INPUT_STREAM (stream), NULL);
+
     return g_object_new (AXING_TYPE_RESOURCE,
                          "file", file,
                          "input-stream", stream,
@@ -160,13 +152,21 @@ axing_resource_new (GFile        *file,
 GFile *
 axing_resource_get_file (AxingResource *resource)
 {
-    return resource->priv->file;
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
+    g_return_val_if_fail (AXING_IS_RESOURCE (resource), NULL);
+
+    return priv->file;
 }
 
 GInputStream *
 axing_resource_get_input_stream (AxingResource *resource)
 {
-    return resource->priv->input;
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
+    g_return_val_if_fail (AXING_IS_RESOURCE (resource), NULL);
+
+    return priv->input;
 }
 
 GInputStream *
@@ -174,11 +174,15 @@ axing_resource_read (AxingResource  *resource,
                      GCancellable   *cancellable,
                      GError        **error)
 {
-    if (resource->priv->input) {
-        return resource->priv->input;
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
+    g_return_val_if_fail (AXING_IS_RESOURCE (resource), NULL);
+
+    if (priv->input) {
+        return priv->input;
     }
     else {
-        return (GInputStream *) g_file_read (resource->priv->file,
+        return (GInputStream *) g_file_read (priv->file,
                                              cancellable,
                                              error);
     }
@@ -189,16 +193,17 @@ resource_file_read_cb (GFile         *file,
                        GAsyncResult  *result,
                        AxingResource *resource)
 {
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
     GError *error = NULL;
 
-    resource->priv->input = G_INPUT_STREAM (g_file_read_finish (file, result, &error));
+    priv->input = G_INPUT_STREAM (g_file_read_finish (file, result, &error));
 
     if (error) {
-        g_simple_async_result_set_from_error (resource->priv->result, error);
+        g_simple_async_result_set_from_error (priv->result, error);
         g_error_free (error);
     }
 
-    g_simple_async_result_complete (resource->priv->result);
+    g_simple_async_result_complete (priv->result);
 }
 
 void
@@ -207,14 +212,20 @@ axing_resource_read_async (AxingResource       *resource,
                            GAsyncReadyCallback  callback,
                            gpointer             user_data)
 {
-    resource->priv->result = g_simple_async_result_new (G_OBJECT (resource),
-                                                        callback, user_data,
-                                                        axing_resource_read_async);
-    if (resource->priv->input) {
-        g_simple_async_result_complete_in_idle (resource->priv->result);
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
+
+    g_return_if_fail (AXING_IS_RESOURCE (resource));
+    g_return_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable));
+    g_return_if_fail (callback != NULL);
+
+    priv->result = g_simple_async_result_new (G_OBJECT (resource),
+                                              callback, user_data,
+                                              axing_resource_read_async);
+    if (priv->input) {
+        g_simple_async_result_complete_in_idle (priv->result);
     }
     else {
-        g_file_read_async (resource->priv->file,
+        g_file_read_async (priv->file,
                            G_PRIORITY_DEFAULT,
                            cancellable,
                            (GAsyncReadyCallback) resource_file_read_cb,
@@ -227,10 +238,15 @@ axing_resource_read_finish (AxingResource *resource,
                             GAsyncResult  *res,
                             GError       **error)
 {
-    g_simple_async_result_propagate_error (resource->priv->result, error);
+    AxingResourcePrivate *priv = axing_resource_get_instance_private (resource);
 
-    if (resource->priv->input)
-        return g_object_ref (resource->priv->input);
+    g_return_val_if_fail (AXING_IS_RESOURCE (resource), NULL);
+    g_return_val_if_fail (G_IS_ASYNC_RESULT (res), NULL);
+
+    g_simple_async_result_propagate_error (priv->result, error);
+
+    if (priv->input)
+        return g_object_ref (priv->input);
     else
         return NULL;
 }

--- a/axing-resource.h
+++ b/axing-resource.h
@@ -29,22 +29,8 @@
 G_BEGIN_DECLS
 
 #define AXING_TYPE_RESOURCE            (axing_resource_get_type ())
-#define AXING_RESOURCE(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_RESOURCE, AxingResource))
-#define AXING_RESOURCE_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_RESOURCE, AxingResourceClass))
-#define AXING_IS_RESOURCE(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_RESOURCE))
-#define AXING_IS_RESOURCE_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_RESOURCE))
-#define AXING_RESOURCE_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_RESOURCE, AxingResourceClass))
 
-typedef struct _AxingResource        AxingResource;
-typedef struct _AxingResourcePrivate AxingResourcePrivate;
-typedef struct _AxingResourceClass   AxingResourceClass;
-
-struct _AxingResource {
-    GObject parent;
-
-    /*< private >*/
-    AxingResourcePrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE (AxingResource, axing_resource, AXING, RESOURCE, GObject)
 
 struct _AxingResourceClass {
     GObjectClass parent_class;
@@ -57,8 +43,6 @@ struct _AxingResourceClass {
     void (*_axing_reserved5) (void);
 };
 
-
-GType                axing_resource_get_type           (void);
 
 AxingResource *      axing_resource_new                (GFile               *file,
                                                         GInputStream        *stream);

--- a/axing-simple-resolver.c
+++ b/axing-simple-resolver.c
@@ -23,14 +23,15 @@
 #include "axing-simple-resolver.h"
 #include "axing-utils.h"
 
-struct _AxingSimpleResolverPrivate {
-    gpointer reserved;
+struct _AxingSimpleResolver
+{
+  AxingResolver parent_instance;
 };
 
-static void      axing_simple_resolver_init           (AxingSimpleResolver       *resolver);
-static void      axing_simple_resolver_class_init     (AxingSimpleResolverClass  *klass);
-static void      axing_simple_resolver_dispose        (GObject                   *object);
-static void      axing_simple_resolver_finalize       (GObject                   *object);
+struct _AxingSimpleResolverClass
+{
+  AxingResolver parent_class;
+};
 
 static AxingResource * simple_resolver_resolve        (AxingResolver        *resolver,
                                                        AxingResource        *base,
@@ -53,41 +54,21 @@ static AxingResource * simple_resolver_resolve_finish (AxingResolver        *res
                                                        GAsyncResult         *result,
                                                        GError              **error);
 
-G_DEFINE_TYPE (AxingSimpleResolver, axing_simple_resolver, AXING_TYPE_RESOLVER);
-
-static void
-axing_simple_resolver_init (AxingSimpleResolver *resolver)
-{
-    resolver->priv = G_TYPE_INSTANCE_GET_PRIVATE (resolver, AXING_TYPE_SIMPLE_RESOLVER,
-                                                  AxingSimpleResolverPrivate);
-}
+G_DEFINE_TYPE (AxingSimpleResolver, axing_simple_resolver, AXING_TYPE_RESOLVER)
 
 static void
 axing_simple_resolver_class_init (AxingSimpleResolverClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
     AxingResolverClass *resolver_class = AXING_RESOLVER_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (AxingSimpleResolverPrivate));
 
     resolver_class->resolve = simple_resolver_resolve;
     resolver_class->resolve_async = simple_resolver_resolve_async;
     resolver_class->resolve_finish = simple_resolver_resolve_finish;
-
-    object_class->dispose = axing_simple_resolver_dispose;
-    object_class->finalize = axing_simple_resolver_finalize;
 }
 
 static void
-axing_simple_resolver_dispose (GObject *object)
+axing_simple_resolver_init (AxingSimpleResolver *resolver)
 {
-    G_OBJECT_CLASS (axing_simple_resolver_parent_class)->dispose (object);
-}
-
-static void
-axing_simple_resolver_finalize (GObject *object)
-{
-    G_OBJECT_CLASS (axing_simple_resolver_parent_class)->finalize (object);
 }
 
 AxingResolver *

--- a/axing-simple-resolver.h
+++ b/axing-simple-resolver.h
@@ -29,37 +29,10 @@
 G_BEGIN_DECLS
 
 #define AXING_TYPE_SIMPLE_RESOLVER            (axing_simple_resolver_get_type ())
-#define AXING_SIMPLE_RESOLVER(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_SIMPLE_RESOLVER, AxingSimpleResolver))
-#define AXING_SIMPLE_RESOLVER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_SIMPLE_RESOLVER, AxingSimpleResolverClass))
-#define AXING_IS_SIMPLE_RESOLVER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_SIMPLE_RESOLVER))
-#define AXING_IS_SIMPLE_RESOLVER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_SIMPLE_RESOLVER))
-#define AXING_SIMPLE_RESOLVER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_SIMPLE_RESOLVER, AxingSimpleResolverClass))
 
-typedef struct _AxingSimpleResolver         AxingSimpleResolver;
-typedef struct _AxingSimpleResolverPrivate  AxingSimpleResolverPrivate;
-typedef struct _AxingSimpleResolverClass    AxingSimpleResolverClass;
+G_DECLARE_FINAL_TYPE (AxingSimpleResolver, axing_simple_resolver, AXING, SIMPLE_RESOLVER, AxingResolver)
 
-struct _AxingSimpleResolver {
-    AxingResolver parent;
-
-    /*< private >*/
-    AxingSimpleResolverPrivate *priv;
-};
-
-struct _AxingSimpleResolverClass {
-    AxingResolverClass parent_class;
-
-    /*< private >*/
-    void (*_axing_reserved1) (void);
-    void (*_axing_reserved2) (void);
-    void (*_axing_reserved3) (void);
-    void (*_axing_reserved4) (void);
-    void (*_axing_reserved5) (void);
-};
-
-GType            axing_simple_resolver_get_type         (void);
-
-AxingResolver *  axing_simple_resolver_new              (void);
+AxingResolver * axing_simple_resolver_new       (void);
 
 G_END_DECLS
 

--- a/axing-stream.c
+++ b/axing-stream.c
@@ -22,23 +22,6 @@
 
 #include "axing-stream.h"
 
-struct _AxingStreamPrivate {
-    gpointer reserved;
-};
-
-static void      axing_stream_init          (AxingStream       *stream);
-static void      axing_stream_class_init    (AxingStreamClass  *klass);
-static void      axing_stream_dispose       (GObject           *object);
-static void      axing_stream_finalize      (GObject           *object);
-static void      axing_stream_get_property  (GObject           *object,
-                                             guint              prop_id,
-                                             GValue            *value,
-                                             GParamSpec        *pspec);
-static void      axing_stream_set_property  (GObject           *object,
-                                             guint              prop_id,
-                                             const GValue      *value,
-                                             GParamSpec        *pspec);
-
 static void      stream_event_default       (AxingStream       *stream);
 
 
@@ -48,28 +31,17 @@ enum {
 };
 static gint signals[LAST_SIGNAL] = { 0 };
 
-G_DEFINE_TYPE (AxingStream, axing_stream, G_TYPE_OBJECT);
+G_DEFINE_ABSTRACT_TYPE (AxingStream, axing_stream, G_TYPE_OBJECT)
 
 static void
 axing_stream_init (AxingStream *stream)
 {
-    stream->priv = G_TYPE_INSTANCE_GET_PRIVATE (stream, AXING_TYPE_STREAM,
-                                                AxingStreamPrivate);
 }
 
 static void
 axing_stream_class_init (AxingStreamClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (AxingStreamPrivate));
-
     klass->stream_event = stream_event_default;
-
-    object_class->get_property = axing_stream_get_property;
-    object_class->set_property = axing_stream_set_property;
-    object_class->dispose = axing_stream_dispose;
-    object_class->finalize = axing_stream_finalize;
 
     signals[STREAM_EVENT] = g_signal_new ("stream-event",
                                           G_TYPE_FROM_CLASS (klass),
@@ -78,34 +50,6 @@ axing_stream_class_init (AxingStreamClass *klass)
                                           NULL, NULL,
                                           g_cclosure_marshal_VOID__VOID,
                                           G_TYPE_NONE, 0);
-}
-
-static void
-axing_stream_dispose (GObject *object)
-{
-    G_OBJECT_CLASS (axing_stream_parent_class)->dispose (object);
-}
-
-static void
-axing_stream_finalize (GObject *object)
-{
-    G_OBJECT_CLASS (axing_stream_parent_class)->finalize (object);
-}
-
-static void
-axing_stream_get_property (GObject    *object,
-                           guint       prop_id,
-                           GValue     *value,
-                           GParamSpec *pspec)
-{
-}
-
-static void
-axing_stream_set_property (GObject      *object,
-                           guint         prop_id,
-                           const GValue *value,
-                           GParamSpec   *pspec)
-{
 }
 
 AxingStreamEventType

--- a/axing-stream.h
+++ b/axing-stream.h
@@ -28,11 +28,8 @@
 G_BEGIN_DECLS
 
 #define AXING_TYPE_STREAM            (axing_stream_get_type ())
-#define AXING_STREAM(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_STREAM, AxingStream))
-#define AXING_STREAM_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_STREAM, AxingStreamClass))
-#define AXING_IS_STREAM(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_STREAM))
-#define AXING_IS_STREAM_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_STREAM))
-#define AXING_STREAM_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_STREAM, AxingStreamClass))
+
+G_DECLARE_DERIVABLE_TYPE (AxingStream, axing_stream, AXING, STREAM, GObject)
 
 typedef enum {
     AXING_STREAM_EVENT_NONE,
@@ -77,17 +74,6 @@ typedef enum {
   get_xml_lang
  */
 
-typedef struct _AxingStream         AxingStream;
-typedef struct _AxingStreamPrivate  AxingStreamPrivate;
-typedef struct _AxingStreamClass    AxingStreamClass;
-
-struct _AxingStream {
-    GObject parent;
-
-    /*< private >*/
-    AxingStreamPrivate *priv;
-};
-
 struct _AxingStreamClass {
     GObjectClass parent_class;
 
@@ -120,8 +106,6 @@ struct _AxingStreamClass {
 };
 
 
-GType                  axing_stream_get_type                (void);
-
 AxingStreamEventType   axing_stream_get_event_type          (AxingStream   *stream);
 const char *           axing_stream_get_event_qname         (AxingStream   *stream);
 const char *           axing_stream_get_event_localname     (AxingStream   *stream);
@@ -144,7 +128,7 @@ void                   axing_stream_emit_event              (AxingStream   *stre
 
 #ifdef FIXME_utility_functions
 void         axing_stream_skip_current_element (AxingStream  *stream);
-gboolean    axing_stream_event_is_empty_element (AxingStreamEvent *event);
+gboolean     axing_stream_event_is_empty_element (AxingStreamEvent *event);
 #endif
 
 G_END_DECLS

--- a/axing-utils.c
+++ b/axing-utils.c
@@ -90,7 +90,7 @@ axing_uri_parse (const char *str)
     return uri;
 }
 
-char *
+static char *
 axing_uri_remove_dots (const char *path)
 {
     GString *ret = g_string_new_len (NULL, strlen(path));
@@ -136,7 +136,7 @@ axing_uri_remove_dots (const char *path)
     return g_string_free (ret, FALSE);
 }
 
-char *
+static char *
 axing_uri_to_string (AxingUri *uri)
 {
     return g_strconcat (uri->scheme ? uri->scheme : "",

--- a/axing-xml-parser.c
+++ b/axing-xml-parser.c
@@ -144,6 +144,7 @@ struct _ParserContext {
     char              *entname;
     char              *showname;
 
+    XmlVersion     xml_version;
     ParserState    state;
     ParserState    init_state;
     ParserState    prev_state;
@@ -175,7 +176,7 @@ struct _ParserContext {
     ParserContext *parent;
 };
 
-struct _AxingXmlParserPrivate {
+typedef struct {
     gboolean    async;
 
     AxingResource      *resource;
@@ -204,10 +205,8 @@ struct _AxingXmlParserPrivate {
     AttributeData      **event_attrvals;
 
     AxingDtdSchema      *doctype;
-};
+} AxingXmlParserPrivate;
 
-static void      axing_xml_parser_init          (AxingXmlParser       *parser);
-static void      axing_xml_parser_class_init    (AxingXmlParserClass  *klass);
 static void      axing_xml_parser_dispose       (GObject              *object);
 static void      axing_xml_parser_finalize      (GObject              *object);
 static void      axing_xml_parser_get_property  (GObject              *object,
@@ -314,16 +313,16 @@ enum {
 };
 
 G_DEFINE_TYPE_WITH_CODE (AxingXmlParser, axing_xml_parser, AXING_TYPE_STREAM,
+                         G_ADD_PRIVATE (AxingXmlParser)
                          G_IMPLEMENT_INTERFACE (AXING_TYPE_NAMESPACE_MAP,
                                                 namespace_map_interface_init));
 
 static void
 axing_xml_parser_init (AxingXmlParser *parser)
 {
-    parser->priv = G_TYPE_INSTANCE_GET_PRIVATE (parser, AXING_TYPE_XML_PARSER,
-                                                AxingXmlParserPrivate);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
 
-    parser->priv->event_stack = g_array_new (FALSE, FALSE, sizeof(ParserStackFrame));
+    priv->event_stack = g_array_new (FALSE, FALSE, sizeof(ParserStackFrame));
 }
 
 static void
@@ -331,8 +330,6 @@ axing_xml_parser_class_init (AxingXmlParserClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
     AxingStreamClass *stream_class = AXING_STREAM_CLASS (klass);
-
-    g_type_class_add_private (klass, sizeof (AxingXmlParserPrivate));
 
     stream_class->get_event_type = stream_get_event_type;
     stream_class->get_event_qname = stream_get_event_qname;
@@ -375,13 +372,14 @@ static void
 axing_xml_parser_dispose (GObject *object)
 {
     AxingXmlParser *parser = AXING_XML_PARSER (object);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
 
-    g_clear_object (&parser->priv->resource);
-    g_clear_object (&parser->priv->resolver);
-    g_clear_object (&parser->priv->context);
-    g_clear_object (&parser->priv->cancellable);
-    g_clear_object (&parser->priv->result);
-    g_clear_object (&parser->priv->doctype);
+    g_clear_object (&priv->resource);
+    g_clear_object (&priv->resolver);
+    g_clear_object (&priv->context);
+    g_clear_object (&priv->cancellable);
+    g_clear_object (&priv->result);
+    g_clear_object (&priv->doctype);
 
     G_OBJECT_CLASS (axing_xml_parser_parent_class)->dispose (object);
 }
@@ -390,13 +388,11 @@ static void
 axing_xml_parser_finalize (GObject *object)
 {
     AxingXmlParser *parser = AXING_XML_PARSER (object);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
 
-    g_clear_error (&(parser->priv->error));
-
+    g_clear_error (&priv->error);
     parser_clean_event_data (parser);
-
-    if (parser->priv->event_stack)
-        g_array_free (parser->priv->event_stack, TRUE);
+    g_array_free (priv->event_stack, TRUE);
 
     G_OBJECT_CLASS (axing_xml_parser_parent_class)->finalize (object);
 }
@@ -408,12 +404,13 @@ axing_xml_parser_get_property (GObject    *object,
                                GParamSpec *pspec)
 {
     AxingXmlParser *parser = AXING_XML_PARSER (object);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
     switch (prop_id) {
     case PROP_RESOURCE:
-        g_value_set_object (value, parser->priv->resource);
+        g_value_set_object (value, priv->resource);
         break;
     case PROP_RESOLVER:
-        g_value_set_object (value, parser->priv->resolver);
+        g_value_set_object (value, priv->resolver);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -427,16 +424,13 @@ axing_xml_parser_set_property (GObject      *object,
                                GParamSpec   *pspec)
 {
     AxingXmlParser *parser = AXING_XML_PARSER (object);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
     switch (prop_id) {
     case PROP_RESOURCE:
-        if (parser->priv->resource)
-            g_object_unref (parser->priv->resource);
-        parser->priv->resource = AXING_RESOURCE (g_value_dup_object (value));
+        priv->resource = AXING_RESOURCE (g_value_dup_object (value));
         break;
     case PROP_RESOLVER:
-        if (parser->priv->resolver)
-            g_object_unref (parser->priv->resolver);
-        parser->priv->resolver = AXING_RESOLVER (g_value_dup_object (value));
+        priv->resolver = AXING_RESOLVER (g_value_dup_object (value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -469,13 +463,14 @@ namespace_map_get_namespace (AxingNamespaceMap *map,
                              const char        *prefix)
 {
     AxingXmlParser *parser = AXING_XML_PARSER (map);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
     ParserStackFrame frame;
     int i;
     if (g_str_equal (prefix, "xml")) {
         return NS_XML;
     }
-    for (i = parser->priv->event_stack->len - 1; i >= 0; i--) {
-        frame = g_array_index (parser->priv->event_stack, ParserStackFrame, i);
+    for (i = priv->event_stack->len - 1; i >= 0; i--) {
+        frame = g_array_index (priv->event_stack, ParserStackFrame, i);
         if (frame.nshash != NULL) {
             const char *ns = g_hash_table_lookup (frame.nshash, prefix);
             if (ns != NULL) {
@@ -489,124 +484,122 @@ namespace_map_get_namespace (AxingNamespaceMap *map,
 static void
 parser_clean_event_data (AxingXmlParser *parser)
 {
-    g_clear_pointer (&parser->priv->event_qname, g_free);
-    g_clear_pointer (&parser->priv->event_prefix, g_free);
-    g_clear_pointer (&parser->priv->event_localname, g_free);
-    g_clear_pointer (&parser->priv->event_namespace, g_free);
-    g_clear_pointer (&parser->priv->event_content, g_free);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
 
-    if (parser->priv->event_attrvals != NULL) {
+    g_clear_pointer (&priv->event_qname, g_free);
+    g_clear_pointer (&priv->event_prefix, g_free);
+    g_clear_pointer (&priv->event_localname, g_free);
+    g_clear_pointer (&priv->event_namespace, g_free);
+    g_clear_pointer (&priv->event_content, g_free);
+
+    if (priv->event_attrvals != NULL) {
         gint i;
-        for (i = 0; parser->priv->event_attrvals[i] != NULL; i++)
-            attribute_data_free (parser->priv->event_attrvals[i]);
+        for (i = 0; priv->event_attrvals[i] != NULL; i++)
+            attribute_data_free (priv->event_attrvals[i]);
 
-        g_clear_pointer (&parser->priv->event_attrvals, g_free);
+        g_clear_pointer (&priv->event_attrvals, g_free);
     }
     /* strings owned by AttributeData structs */
-    g_clear_pointer (&parser->priv->event_attrkeys, g_free);
+    g_clear_pointer (&priv->event_attrkeys, g_free);
 
-    parser->priv->event_type = AXING_STREAM_EVENT_NONE;
+    priv->event_type = AXING_STREAM_EVENT_NONE;
 }
 
 static AxingStreamEventType
 stream_get_event_type (AxingStream *stream)
 {
-    return AXING_XML_PARSER (stream)->priv->event_type;
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+
+    return priv->event_type;
 }
 
 static const char *
 stream_get_event_qname (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
                           NULL);
-    return parser->priv->event_qname;
+    return priv->event_qname;
 }
 
 static const char *
 stream_get_event_content (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_CONTENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_COMMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_CDATA   ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_CONTENT ||
+                          priv->event_type == AXING_STREAM_EVENT_COMMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_CDATA   ||
+                          priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
                           NULL);
-    g_return_val_if_fail (parser->priv->event_type != AXING_STREAM_EVENT_NONE, NULL);
-    return parser->priv->event_content;
+    g_return_val_if_fail (priv->event_type != AXING_STREAM_EVENT_NONE, NULL);
+    return priv->event_content;
 }
 
 static const char *
 stream_get_event_prefix (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
                           NULL);
-    return parser->priv->event_prefix ? parser->priv->event_prefix : "";
+    return priv->event_prefix ? priv->event_prefix : "";
 }
 
 static const char *
 stream_get_event_localname (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
                           NULL);
-    return parser->priv->event_localname ? parser->priv->event_localname : parser->priv->event_qname;
+    return priv->event_localname ? priv->event_localname : priv->event_qname;
 }
 
 static const char *
 stream_get_event_namespace (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
-                          parser->priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_END_ELEMENT ||
+                          priv->event_type == AXING_STREAM_EVENT_INSTRUCTION,
                           NULL);
-    return parser->priv->event_namespace ? parser->priv->event_namespace : "";
+    return priv->event_namespace ? priv->event_namespace : "";
 }
 
-static char *nokeys[1] = {NULL};
+static const char *nokeys[1] = {NULL};
 
 const char * const *
 stream_get_attributes (AxingStream *stream)
 {
-    AxingXmlParser *parser;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
-    if (parser->priv->event_attrkeys == NULL) {
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
+    if (priv->event_attrkeys == NULL) {
         return (const char * const *) nokeys;
     }
-    return (const char * const *) parser->priv->event_attrkeys;
+    return (const char * const *) priv->event_attrkeys;
 }
 
 const char *
 stream_get_attribute_localname (AxingStream *stream,
                                 const char  *qname)
 {
-    AxingXmlParser *parser;
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
     int i;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
-    for (i = 0; parser->priv->event_attrvals[i] != NULL; i++) {
-        AttributeData *data = parser->priv->event_attrvals[i];
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
+    for (i = 0; priv->event_attrvals[i] != NULL; i++) {
+        AttributeData *data = priv->event_attrvals[i];
         if (g_str_equal (qname, data->qname)) {
             return data->localname ? data->localname : data->qname;
         }
@@ -618,13 +611,12 @@ const char *
 stream_get_attribute_prefix (AxingStream *stream,
                              const char  *qname)
 {
-    AxingXmlParser *parser;
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
     int i;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
-    for (i = 0; parser->priv->event_attrvals[i] != NULL; i++) {
-        AttributeData *data = parser->priv->event_attrvals[i];
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
+    for (i = 0; priv->event_attrvals[i] != NULL; i++) {
+        AttributeData *data = priv->event_attrvals[i];
         if (g_str_equal (qname, data->qname)) {
             return data->prefix ? data->prefix : "";
         }
@@ -636,13 +628,12 @@ const char *
 stream_get_attribute_namespace (AxingStream *stream,
                                 const char  *qname)
 {
-    AxingXmlParser *parser;
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
     int i;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
-    for (i = 0; parser->priv->event_attrvals[i] != NULL; i++) {
-        AttributeData *data = parser->priv->event_attrvals[i];
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
+    for (i = 0; priv->event_attrvals[i] != NULL; i++) {
+        AttributeData *data = priv->event_attrvals[i];
         if (g_str_equal (qname, data->qname)) {
             return data->namespace ? data->namespace : "";
         }
@@ -655,13 +646,12 @@ stream_get_attribute_value (AxingStream *stream,
                             const char  *name,
                             const char  *ns)
 {
-    AxingXmlParser *parser;
+    AxingXmlParserPrivate *priv =
+      axing_xml_parser_get_instance_private (AXING_XML_PARSER (stream));
     int i;
-    g_return_val_if_fail (AXING_IS_XML_PARSER (stream), NULL);
-    parser = (AxingXmlParser *) stream;
-    g_return_val_if_fail (parser->priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
-    for (i = 0; parser->priv->event_attrvals[i] != NULL; i++) {
-        AttributeData *data = parser->priv->event_attrvals[i];
+    g_return_val_if_fail (priv->event_type == AXING_STREAM_EVENT_START_ELEMENT, NULL);
+    for (i = 0; priv->event_attrvals[i] != NULL; i++) {
+        AttributeData *data = priv->event_attrvals[i];
         if (ns == NULL) {
             if (g_str_equal (name, data->qname))
                 return data->value;
@@ -679,15 +669,18 @@ static void
 axing_xml_parser_parse_init (AxingXmlParser *parser,
                              GCancellable   *cancellable)
 {
-    parser->priv->context = context_new (parser);
-    parser->priv->context->state = PARSER_STATE_START;
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
 
-    parser->priv->context->resource = g_object_ref (parser->priv->resource);
+    priv->context = context_new (parser);
+    priv->context->state = PARSER_STATE_START;
+
+    priv->context->resource = g_object_ref (priv->resource);
 
     if (cancellable)
-        parser->priv->cancellable = g_object_ref (cancellable);
+        priv->cancellable = g_object_ref (cancellable);
 
-    parser->priv->context->basename = resource_get_basename (parser->priv->resource);
+    priv->context->basename = resource_get_basename (priv->resource);
+    priv->context->xml_version = priv->xml_version;
 }
 
 void
@@ -695,34 +688,37 @@ axing_xml_parser_parse (AxingXmlParser  *parser,
                         GCancellable    *cancellable,
                         GError         **error)
 {
-    g_return_if_fail (parser->priv->context == NULL);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
+
+    g_return_if_fail (priv->context == NULL);
 
     axing_xml_parser_parse_init (parser, cancellable);
 
-    parser->priv->async = FALSE;
+    priv->async = FALSE;
 
-    context_parse_sync (parser->priv->context);
+    context_parse_sync (priv->context);
 
-    context_free (parser->priv->context);
-    parser->priv->context = NULL;
-    if (parser->priv->error) {
+    context_free (priv->context);
+    priv->context = NULL;
+    if (priv->error) {
         if (error != NULL)
-            *error = parser->priv->error;
+            *error = priv->error;
         else
-            g_error_free (parser->priv->error);
-        parser->priv->error = NULL;
+            g_error_free (priv->error);
+        priv->error = NULL;
     }
 }
 
 static void
 context_parse_sync (ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     char *line;
 
     context->srcstream = axing_resource_read (context->resource,
-                                              context->parser->priv->cancellable,
-                                              &(context->parser->priv->error));
-    if (context->parser->priv->error)
+                                              priv->cancellable,
+                                              &priv->error);
+    if (priv->error)
         goto error;
 
     context->datastream = g_data_input_stream_new (context->srcstream);
@@ -730,26 +726,26 @@ context_parse_sync (ParserContext *context)
         gboolean reencoded;
         g_buffered_input_stream_fill (G_BUFFERED_INPUT_STREAM (context->datastream),
                                       1024,
-                                      context->parser->priv->cancellable,
-                                      &(context->parser->priv->error));
-        if (context->parser->priv->error)
+                                      priv->cancellable,
+                                      &priv->error);
+        if (priv->error)
             goto error;
 
         reencoded = context_parse_bom (context);
-        if (context->parser->priv->error)
+        if (priv->error)
             goto error;
 
         if (reencoded) {
             g_buffered_input_stream_fill (G_BUFFERED_INPUT_STREAM (context->datastream),
                                           1024,
-                                          context->parser->priv->cancellable,
-                                          &(context->parser->priv->error));
-            if (context->parser->priv->error)
+                                          priv->cancellable,
+                                          &priv->error);
+            if (priv->error)
                 goto error;
         }
 
         context_parse_xml_decl (context);
-        if (context->parser->priv->error)
+        if (priv->error)
             goto error;
 
         if (context->state == PARSER_STATE_TEXTDECL)
@@ -759,27 +755,27 @@ context_parse_sync (ParserContext *context)
     g_data_input_stream_set_newline_type (context->datastream,
                                           G_DATA_STREAM_NEWLINE_TYPE_ANY);
     while ((line = g_data_input_stream_read_upto (context->datastream, " ", -1, NULL,
-                                                  context->parser->priv->cancellable,
-                                                  &(context->parser->priv->error)) )) {
-        if (context->parser->priv->error)
+                                                  priv->cancellable,
+                                                  &priv->error) )) {
+        if (priv->error)
             goto error;
         context_parse_data (context, line);
         g_free (line);
-        if (context->parser->priv->error)
+        if (priv->error)
             goto error;
         if (g_buffered_input_stream_get_available (G_BUFFERED_INPUT_STREAM (context->datastream)) > 0) {
             char eol[2] = {0, 0};
             eol[0] = g_data_input_stream_read_byte (context->datastream,
-                                                    context->parser->priv->cancellable,
-                                                    &(context->parser->priv->error));
-            if (context->parser->priv->error)
+                                                    priv->cancellable,
+                                                    &priv->error);
+            if (priv->error)
                 goto error;
             context_parse_data (context, eol);
-            if (context->parser->priv->error)
+            if (priv->error)
                 goto error;
         }
     }
-    if (line == NULL && context->parser->priv->error == NULL)
+    if (line == NULL && priv->error == NULL)
         context_check_end (context);
 
  error:
@@ -792,19 +788,21 @@ axing_xml_parser_parse_async (AxingXmlParser      *parser,
                               GAsyncReadyCallback  callback,
                               gpointer             user_data)
 {
-    g_return_if_fail (parser->priv->context == NULL);
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
+
+    g_return_if_fail (priv->context == NULL);
 
     axing_xml_parser_parse_init (parser, cancellable);
 
-    parser->priv->async = TRUE;
-    parser->priv->result = g_simple_async_result_new (G_OBJECT (parser),
-                                                      callback, user_data,
-                                                      axing_xml_parser_parse_async);
+    priv->async = TRUE;
+    priv->result = g_simple_async_result_new (G_OBJECT (parser),
+                                              callback, user_data,
+                                              axing_xml_parser_parse_async);
 
-    axing_resource_read_async (parser->priv->resource,
-                               parser->priv->cancellable,
+    axing_resource_read_async (priv->resource,
+                               priv->cancellable,
                                (GAsyncReadyCallback) context_resource_read_cb,
-                               parser->priv->context);
+                               priv->context);
 }
 
 void
@@ -812,27 +810,26 @@ axing_xml_parser_parse_finish (AxingXmlParser *parser,
                                GAsyncResult   *res,
                                GError        **error)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (parser);
+
     g_warn_if_fail (g_simple_async_result_get_source_tag (G_SIMPLE_ASYNC_RESULT (res)) == axing_xml_parser_parse_async);
 
-    if (parser->priv->context) {
-        context_free (parser->priv->context);
-        parser->priv->context = NULL;
-    }
+    g_clear_pointer (&priv->context, context_free);
 
-    if (parser->priv->error) {
+    if (priv->error) {
         if (error != NULL)
-            *error = parser->priv->error;
+            *error = priv->error;
         else
-            g_error_free (parser->priv->error);
-        parser->priv->error = NULL;
+            g_error_free (priv->error);
+        priv->error = NULL;
     }
 }
 
-#define XML_IS_CHAR(cp, context) ((context->parser->priv->xml_version == XML_1_1) ? (cp == 0x09 || cp == 0x0A || cp == 0x0D || (cp >= 0x20 && cp <= 0x7E) || cp == 0x85 || (cp  >= 0xA0 && cp <= 0xD7FF) || (cp >= 0xE000 && cp <= 0xFFFD) || (cp >= 0x10000 && cp <= 0x10FFFF)) : (cp == 0x9 || cp == 0x0A || cp == 0x0D || (cp >= 0x20 && cp <= 0xD7FF) || (cp >= 0xE000 && cp <= 0xFFFD) || (cp >= 0x10000 && cp <= 0x10FFFF)))
+#define XML_IS_CHAR(cp, context) ((context->xml_version == XML_1_1) ? (cp == 0x09 || cp == 0x0A || cp == 0x0D || (cp >= 0x20 && cp <= 0x7E) || cp == 0x85 || (cp  >= 0xA0 && cp <= 0xD7FF) || (cp >= 0xE000 && cp <= 0xFFFD) || (cp >= 0x10000 && cp <= 0x10FFFF)) : (cp == 0x9 || cp == 0x0A || cp == 0x0D || (cp >= 0x20 && cp <= 0xD7FF) || (cp >= 0xE000 && cp <= 0xFFFD) || (cp >= 0x10000 && cp <= 0x10FFFF)))
 
-#define XML_IS_CHAR_RESTRICTED(cp, context) ((context->parser->priv->xml_version == XML_1_1) && ((cp >= 0x1 && cp <= 0x8) || (cp >= 0xB && cp <= 0xC) || (cp >= 0xE && cp <= 0x1F) || (cp >= 0x7F && cp <= 0x84) || (cp >= 0x86 && cp <= 0x9F)))
+#define XML_IS_CHAR_RESTRICTED(cp, context) ((context->xml_version == XML_1_1) && ((cp >= 0x1 && cp <= 0x8) || (cp >= 0xB && cp <= 0xC) || (cp >= 0xE && cp <= 0x1F) || (cp >= 0x7F && cp <= 0x84) || (cp >= 0x86 && cp <= 0x9F)))
 
-#define IS_1_1(context) (context->state != PARSER_STATE_START && context->parser->priv->xml_version == XML_1_1)
+#define IS_1_1(context) (context->state != PARSER_STATE_START && context->xml_version == XML_1_1)
 
 #define XML_IS_SPACE(line, context)                                     \
     ((line)[0] == 0x20 || (line)[0] == 0x09 ||                          \
@@ -886,33 +883,156 @@ axing_xml_parser_parse_finish (AxingXmlParser *parser,
         namevar = g_string_free (name, FALSE);                          \
     }
 
-#define ERROR_SYNTAX(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_SYNTAX, "%s:%i:%i:Syntax error.", context->showname ? context->showname : context->basename, context->linenum, context->colnum); goto error; }
+#define ERROR_SYNTAX(context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_SYNTAX, \
+                              "%s:%i:%i:Syntax error.", \
+                              context->showname ? context->showname : context->basename, \
+                              context->linenum, \
+                              context->colnum); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_DUPATTR(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_DUPATTR, "%s:%i:%i:Duplicate attribute \"%s\".", context->showname ? context->showname : context->basename, context->attr_linenum, context->attr_colnum, context->cur_attrname); goto error; }
+#define ERROR_DUPATTR(context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_DUPATTR, \
+                              "%s:%i:%i:Duplicate attribute \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              context->attr_linenum, \
+                              context->attr_colnum, \
+                              context->cur_attrname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_MISSINGEND(context, qname) { context->parser->priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_MISSINGEND, "%s:%i:%i:Missing end tag for \"%s\".", context->showname ? context->showname : context->basename, context->linenum, context->colnum, qname); goto error; }
+#define ERROR_MISSINGEND(context, qname) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_MISSINGEND, \
+                               "%s:%i:%i:Missing end tag for \"%s\".", \
+                               context->showname ? context->showname : context->basename, \
+                               context->linenum, \
+                               context->colnum, \
+                               qname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_EXTRACONTENT(context) { context->parser->priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_EXTRACONTENT, "%s:%i:%i:Extra content at end of resource.", context->showname ? context->showname : context->basename, context->linenum, context->colnum); goto error; }
+#define ERROR_EXTRACONTENT(context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_EXTRACONTENT, \
+                               "%s:%i:%i:Extra content at end of resource.", \
+                               context->showname ? context->showname : context->basename, \
+                               context->linenum, \
+                               context->colnum); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_WRONGEND(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_WRONGEND, "%s:%i:%i:Incorrect end tag \"%s\".", context->showname ? context->showname : context->basename, context->node_linenum, context->node_colnum, context->parser->priv->event_qname); goto error; }
+#define ERROR_WRONGEND(context,qname) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_WRONGEND, \
+                              "%s:%i:%i:Incorrect end tag \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              context->node_linenum, \
+                              context->node_colnum, \
+                              qname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_ENTITY(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_ENTITY, "%s:%i:%i:Incorrect entity reference.", context->showname ? context->showname : context->basename, context->linenum, context->colnum); goto error; }
+#define ERROR_ENTITY(context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_ENTITY, \
+                              "%s:%i:%i:Incorrect entity reference.", \
+                              context->showname ? context->showname : context->basename, \
+                              context->linenum, \
+                              context->colnum); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_QNAME(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_QNAME, "%s:%i:%i:Could not parse QName \"%s\".", context->showname ? context->showname : context->basename, context->node_linenum, context->node_colnum, context->parser->priv->event_qname); goto error; }
+#define ERROR_NS_QNAME(context,qname) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_QNAME, \
+                              "%s:%i:%i:Could not parse QName \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              context->node_linenum, \
+                              context->node_colnum, \
+                              qname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_QNAME_ATTR(context, data) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_QNAME, "%s:%i:%i:Could not parse QName \"%s\".", context->showname ? context->showname : context->basename, data->linenum, data->colnum, data->qname); goto error; }
+#define ERROR_NS_QNAME_ATTR(context, data) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_QNAME, \
+                              "%s:%i:%i:Could not parse QName \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              data->linenum, \
+                              data->colnum, \
+                              data->qname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_NOTFOUND(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_NOTFOUND, "%s:%i:%i:Could not find namespace for prefix \"%s\".", context->showname ? context->showname : context->basename, context->node_linenum, context->node_colnum, context->parser->priv->event_prefix); goto error; }
+#define ERROR_NS_NOTFOUND(context, prefix) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_NOTFOUND, \
+                              "%s:%i:%i:Could not find namespace for prefix \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              context->node_linenum, \
+                              context->node_colnum, \
+                              prefix); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_NOTFOUND_ATTR(context, data) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_NOTFOUND, "%s:%i:%i:Could not find namespace for prefix \"%s\".", context->showname ? context->showname : context->basename, data->linenum, data->colnum, data->prefix); goto error; }
+#define ERROR_NS_NOTFOUND_ATTR(context, data) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_NOTFOUND, \
+                              "%s:%i:%i:Could not find namespace for prefix \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              data->linenum, \
+                              data->colnum, \
+                              data->prefix); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_DUPATTR(context, data) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_DUPATTR, "%s:%i:%i:Duplicate expanded name for attribute \"%s\".", context->showname ? context->showname : context->basename, data->linenum, data->colnum, data->qname); goto error; }
+#define ERROR_NS_DUPATTR(context, data) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_DUPATTR, \
+                              "%s:%i:%i:Duplicate expanded name for attribute \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              data->linenum, \
+                              data->colnum, \
+                              data->qname); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_NS_INVALID(context, prefix) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_INVALID, "%s:%i:%i:Invalid namespace for prefix \"%s\".", context->showname ? context->showname : context->basename, context->attr_linenum, context->attr_colnum, prefix); goto error; }
+#define ERROR_NS_INVALID(context, prefix) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_NS_INVALID, \
+                              "%s:%i:%i:Invalid namespace for prefix \"%s\".", \
+                              context->showname ? context->showname : context->basename, \
+                              context->attr_linenum, \
+                              context->attr_colnum, \
+                              prefix); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_BOM_ENCODING(context, bomenc, encoding) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_CHARSET, "%s:%i:%i:Detected encoding \"%s\" from BOM, but got \"%s\" from declaration.", context->showname ? context->showname : context->basename, context->linenum, context->colnum, bomenc, encoding); goto error; }
+#define ERROR_BOM_ENCODING(context, bomenc, encoding) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_CHARSET, \
+                              "%s:%i:%i:Detected encoding \"%s\" from BOM, but got \"%s\" from declaration.", \
+                              context->showname ? context->showname : context->basename, \
+                              context->linenum, \
+                              context->colnum, \
+                              bomenc, \
+                              encoding); \
+  goto error; \
+} G_STMT_END
 
-#define ERROR_FIXME(context) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_OTHER, "%s:%i:%i:Unsupported feature.", context->showname ? context->showname : context->basename, context->linenum, context->colnum); goto error; }
+#define ERROR_FIXME(context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_OTHER, \
+                              "%s:%i:%i:Unsupported feature.", \
+                              context->showname ? context->showname : context->basename, \
+                              context->linenum, \
+                              context->colnum); \
+  goto error; \
+} G_STMT_END
 
 #define EAT_SPACES(line, buf, bufsize, context)                         \
     while((bufsize < 0 || (line) - buf < bufsize)) {                    \
@@ -1056,7 +1176,14 @@ axing_xml_parser_parse_finish (AxingXmlParser *parser,
         cur = g_utf8_next_char(cur); context->colnum++;                 \
     }
 
-#define CHECK_BUFFER(c, num, buf, bufsize, context) if (c - buf + num > bufsize) { context->parser->priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_BUFFER, "Insufficient buffer for XML declaration\n"); goto error; }
+#define CHECK_BUFFER(c, num, buf, bufsize, context) G_STMT_START { \
+  AxingXmlParserPrivate *__priv = axing_xml_parser_get_instance_private (context->parser); \
+  if (c - buf + num > bufsize) { \
+    __priv->error = g_error_new(AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_BUFFER, \
+                                "Insufficient buffer for XML declaration"); \
+    goto error; \
+  } \
+} G_STMT_END
 
 #define READ_TO_QUOTE(c, buf, bufsize, context, quot) EAT_SPACES (c, buf, bufsize, context); CHECK_BUFFER (c, 1, buf, bufsize, context); if (c[0] != '=') { ERROR_SYNTAX(context); } c += 1; context->colnum += 1; EAT_SPACES (c, buf, bufsize, context); CHECK_BUFFER (c, 1, buf, bufsize, context); if (c[0] != '"' && c[0] != '\'') { ERROR_SYNTAX(context); } quot = c[0]; c += 1; context->colnum += 1;
 
@@ -1066,9 +1193,9 @@ context_resource_read_cb (AxingResource *resource,
                           GAsyncResult  *result,
                           ParserContext *context)
 {
-    context->srcstream = G_INPUT_STREAM (axing_resource_read_finish (resource, result,
-                                                                     &(context->parser->priv->error)));
-    if (context->parser->priv->error) {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+    context->srcstream = G_INPUT_STREAM (axing_resource_read_finish (resource, result, &priv->error));
+    if (priv->error) {
         context_complete (context);
         return;
     }
@@ -1078,12 +1205,14 @@ context_resource_read_cb (AxingResource *resource,
 static void
 context_start_async (ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+
     context->datastream = g_data_input_stream_new (context->srcstream);
 
     g_buffered_input_stream_fill_async (G_BUFFERED_INPUT_STREAM (context->datastream),
                                         1024,
                                         G_PRIORITY_DEFAULT,
-                                        context->parser->priv->cancellable,
+                                        priv->cancellable,
                                         (GAsyncReadyCallback) context_start_cb,
                                         context);
 }
@@ -1093,13 +1222,15 @@ context_start_cb (GBufferedInputStream *stream,
                   GAsyncResult         *res,
                   ParserContext        *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+
     g_buffered_input_stream_fill_finish (stream, res, NULL);
     if (context->state == PARSER_STATE_START || context->state == PARSER_STATE_TEXTDECL) {
         if (!context->bom_checked) {
             gboolean reencoded;
             context->bom_checked = TRUE;
             reencoded = context_parse_bom (context);
-            if (context->parser->priv->error) {
+            if (priv->error) {
                 context_complete (context);
                 return;
             }
@@ -1107,7 +1238,7 @@ context_start_cb (GBufferedInputStream *stream,
                 g_buffered_input_stream_fill_async (G_BUFFERED_INPUT_STREAM (context->datastream),
                                                     1024,
                                                     G_PRIORITY_DEFAULT,
-                                                    context->parser->priv->cancellable,
+                                                    priv->cancellable,
                                                     (GAsyncReadyCallback) context_start_cb,
                                                     context);
                 return;
@@ -1115,7 +1246,7 @@ context_start_cb (GBufferedInputStream *stream,
         }
 
         context_parse_xml_decl (context);
-        if (context->parser->priv->error) {
+        if (priv->error) {
             context_complete (context);
             return;
         }
@@ -1128,7 +1259,7 @@ context_start_cb (GBufferedInputStream *stream,
     g_data_input_stream_read_upto_async (context->datastream,
                                          " ", -1,
                                          G_PRIORITY_DEFAULT,
-                                         context->parser->priv->cancellable,
+                                         priv->cancellable,
                                          (GAsyncReadyCallback) context_read_data_cb,
                                          context);
 }
@@ -1138,8 +1269,9 @@ context_read_data_cb (GDataInputStream *stream,
                       GAsyncResult     *res,
                       ParserContext    *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     gchar *line;
-    if (context->parser->priv->error) {
+    if (priv->error) {
         context_complete (context);
         return;
     }
@@ -1150,8 +1282,8 @@ context_read_data_cb (GDataInputStream *stream,
         g_free (line);
     }
     else {
-        line = g_data_input_stream_read_upto_finish (stream, res, NULL, &(context->parser->priv->error));
-        if (line == NULL && context->parser->priv->error == NULL) {
+        line = g_data_input_stream_read_upto_finish (stream, res, NULL, &priv->error);
+        if (line == NULL && priv->error == NULL) {
             /* https://bugzilla.gnome.org/show_bug.cgi?id=692101
                g_data_input_stream_read_upto_finish returns NULL when it should return ""
                when at one of the stop chars. This happens, e.g., when there are two stop
@@ -1163,13 +1295,13 @@ context_read_data_cb (GDataInputStream *stream,
                 goto bug692101;
             context_check_end (context);
         }
-        if (line == NULL || context->parser->priv->error) {
+        if (line == NULL || priv->error) {
             context_complete (context);
             return;
         }
         context_parse_data (context, line);
         g_free (line);
-        if (context->parser->priv->error) {
+        if (priv->error) {
             context_complete (context);
             return;
         }
@@ -1177,14 +1309,14 @@ context_read_data_cb (GDataInputStream *stream,
         if (g_buffered_input_stream_get_available (G_BUFFERED_INPUT_STREAM (context->datastream)) > 0) {
             char eol[2] = {0, 0};
             eol[0] = g_data_input_stream_read_byte (context->datastream,
-                                                    context->parser->priv->cancellable,
-                                                    &(context->parser->priv->error));
-            if (context->parser->priv->error) {
+                                                    priv->cancellable,
+                                                    &priv->error);
+            if (priv->error) {
                 context_complete (context);
                 return;
             }
             context_parse_data (context, eol);
-            if (context->parser->priv->error) {
+            if (priv->error) {
                 context_complete (context);
                 return;
             }
@@ -1194,7 +1326,7 @@ context_read_data_cb (GDataInputStream *stream,
         g_data_input_stream_read_upto_async (context->datastream,
                                              " ", -1,
                                              G_PRIORITY_DEFAULT,
-                                             context->parser->priv->cancellable,
+                                             priv->cancellable,
                                              (GAsyncReadyCallback) context_read_data_cb,
                                              context);
 }
@@ -1202,10 +1334,12 @@ context_read_data_cb (GDataInputStream *stream,
 static void
 context_check_end (ParserContext *context)
 {
-    if (context->parser->priv->event_stack->len != context->event_stack_root) {
-        ParserStackFrame frame = g_array_index (context->parser->priv->event_stack,
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+
+    if (priv->event_stack->len != context->event_stack_root) {
+        ParserStackFrame frame = g_array_index (priv->event_stack,
                                                 ParserStackFrame,
-                                                context->parser->priv->event_stack->len - 1);
+                                                priv->event_stack->len - 1);
         ERROR_MISSINGEND(context, frame.qname);
     }
     if (context->state != context->init_state &&
@@ -1217,14 +1351,16 @@ context_check_end (ParserContext *context)
 }
 
 static void
-context_set_encoding (ParserContext *context, const char *encoding)
+context_set_encoding (ParserContext *context,
+                      const char *encoding)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     GConverter *converter;
     GInputStream *cstream;
     converter = (GConverter *) g_charset_converter_new ("UTF-8", encoding, NULL);
     if (converter == NULL) {
-        context->parser->priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_CHARSET,
-                                                    "Unsupported character encoding %s\n", encoding);
+        priv->error = g_error_new (AXING_XML_PARSER_ERROR, AXING_XML_PARSER_ERROR_CHARSET,
+                                   "Unsupported character encoding %s\n", encoding);
         return;
     }
     cstream = g_converter_input_stream_new (G_INPUT_STREAM (context->datastream), converter);
@@ -1301,6 +1437,7 @@ context_parse_bom (ParserContext *context)
 static void
 context_parse_xml_decl (ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     gsize bufsize;
     guchar *buf, *c;
     char quot;
@@ -1334,7 +1471,8 @@ context_parse_xml_decl (ParserContext *context)
 
         CHECK_BUFFER (c, 4, buf, bufsize, context);
         if (c[0] == '1' && c[1] == '.' && (c[2] == '0' || c[2] == '1') && c[3] == quot) {
-            context->parser->priv->xml_version = (c[2] == '0') ? XML_1_0 : XML_1_1;
+            context->xml_version = (c[2] == '0') ? XML_1_0 : XML_1_1;
+            priv->xml_version = context->xml_version;
         }
         else {
             ERROR_SYNTAX(context);
@@ -1500,8 +1638,11 @@ context_parse_xml_decl (ParserContext *context)
 }
 
 static void
-context_parse_data (ParserContext *context, char *line)
+context_parse_data (ParserContext *context,
+                    char          *line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+
     /* The parsing functions make these assumptions about the data that gets passed in:
        1) It always has complete UTF-8 characters.
        2) It always terminates somewhere where a space is permissable, e.g. never in
@@ -1523,10 +1664,10 @@ context_parse_data (ParserContext *context, char *line)
             }
             if (c[0] == '<') {
                 if (context->state == PARSER_STATE_TEXT && context->cur_text != NULL) {
-                    g_free (context->parser->priv->event_content);
-                    context->parser->priv->event_content = g_string_free (context->cur_text, FALSE);
+                    g_free (priv->event_content);
+                    priv->event_content = g_string_free (context->cur_text, FALSE);
                     context->cur_text = NULL;
-                    context->parser->priv->event_type = AXING_STREAM_EVENT_CONTENT;
+                    priv->event_type = AXING_STREAM_EVENT_CONTENT;
 
                     axing_stream_emit_event (AXING_STREAM (context->parser));
                     parser_clean_event_data (context->parser);
@@ -1590,7 +1731,7 @@ context_parse_data (ParserContext *context, char *line)
         default:
             g_assert_not_reached ();
         }
-        if (context->parser->priv->error != NULL) {
+        if (priv->error != NULL) {
             return;
         }
     }
@@ -1602,10 +1743,12 @@ static void
 context_parse_doctype (ParserContext  *context,
                        char          **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
+
     switch (context->state) {
     case PARSER_STATE_START:
     case PARSER_STATE_PROLOG:
-        if (context->parser->priv->doctype != NULL) {
+        if (priv->doctype != NULL) {
             ERROR_SYNTAX(context);
         }
         if (!g_str_has_prefix (*line, "<!DOCTYPE")) {
@@ -1632,8 +1775,8 @@ context_parse_doctype (ParserContext  *context,
         XML_GET_NAME(line, doctype, context);
         if (!(XML_IS_SPACE(*line, context) || (*line)[0] == '\0'))
             ERROR_SYNTAX(context);
-        context->parser->priv->doctype = axing_dtd_schema_new ();
-        axing_dtd_schema_set_doctype (context->parser->priv->doctype, doctype);
+        priv->doctype = axing_dtd_schema_new ();
+        axing_dtd_schema_set_doctype (priv->doctype, doctype);
         g_free (doctype);
         context->doctype_state = DOCTYPE_STATE_NAME;
     }
@@ -1686,7 +1829,7 @@ context_parse_doctype (ParserContext  *context,
             if (c == context->quotechar) {
                 char *public = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                axing_dtd_schema_set_public_id (context->parser->priv->doctype, public);
+                axing_dtd_schema_set_public_id (priv->doctype, public);
                 g_free (public);
                 context->doctype_state = DOCTYPE_STATE_SYSTEM;
                 (*line)++; context->colnum++;
@@ -1724,7 +1867,7 @@ context_parse_doctype (ParserContext  *context,
             if ((*line)[0] == context->quotechar) {
                 char *system = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                axing_dtd_schema_set_system_id (context->parser->priv->doctype, system);
+                axing_dtd_schema_set_system_id (priv->doctype, system);
                 g_free (system);
                 context->doctype_state = DOCTYPE_STATE_EXTID;
                 (*line)++; context->colnum++;
@@ -1766,7 +1909,7 @@ context_parse_doctype (ParserContext  *context,
         }
         else if ((*line)[0] == '%') {
             context_parse_parameter (context, line);
-            if (context->parser->priv->error)
+            if (priv->error)
                 goto error;
         }
         else if (g_str_has_prefix (*line, "<!ELEMENT")) {
@@ -1850,6 +1993,7 @@ context_parse_doctype (ParserContext  *context,
 
 static void
 context_parse_doctype_element (ParserContext *context, char **line) {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->doctype_state == DOCTYPE_STATE_INT) {
         g_assert (g_str_has_prefix(*line, "<!ELEMENT"));
         (*line) += 9; context->colnum += 9;
@@ -1919,10 +2063,10 @@ context_parse_doctype_element (ParserContext *context, char **line) {
             ERROR_SYNTAX(context);
         value = g_string_free (context->cur_text, FALSE);
         context->cur_text = NULL;
-        axing_dtd_schema_add_element (context->parser->priv->doctype,
+        axing_dtd_schema_add_element (priv->doctype,
                                       context->cur_qname,
                                       value,
-                                      &(context->parser->priv->error));
+                                      &priv->error);
         g_free (value);
         g_free (context->cur_qname);
         context->cur_qname = NULL;
@@ -1935,6 +2079,7 @@ context_parse_doctype_element (ParserContext *context, char **line) {
 
 static void
 context_parse_doctype_attlist (ParserContext *context, char **line) {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->doctype_state == DOCTYPE_STATE_INT) {
         g_assert (g_str_has_prefix(*line, "<!ATTLIST"));
         (*line) += 9; context->colnum += 9;
@@ -2012,10 +2157,10 @@ context_parse_doctype_attlist (ParserContext *context, char **line) {
             ERROR_SYNTAX(context);
         value = g_string_free (context->cur_text, FALSE);
         context->cur_text = NULL;
-        axing_dtd_schema_add_attlist (context->parser->priv->doctype,
+        axing_dtd_schema_add_attlist (priv->doctype,
                                       context->cur_qname,
                                       value,
-                                      &(context->parser->priv->error));
+                                      &priv->error);
         g_free (value);
         g_free (context->cur_qname);
         context->cur_qname = NULL;
@@ -2029,6 +2174,7 @@ context_parse_doctype_attlist (ParserContext *context, char **line) {
 
 static void
 context_parse_doctype_notation (ParserContext *context, char **line) {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->doctype_state == DOCTYPE_STATE_INT) {
         g_assert (g_str_has_prefix(*line, "<!NOTATION"));
         (*line) += 10; context->colnum += 10;
@@ -2157,7 +2303,7 @@ context_parse_doctype_notation (ParserContext *context, char **line) {
             return;
         if ((*line)[0] != '>')
             ERROR_SYNTAX(context);
-        axing_dtd_schema_add_notation (context->parser->priv->doctype,
+        axing_dtd_schema_add_notation (priv->doctype,
                                        context->cur_qname,
                                        context->decl_public,
                                        context->decl_system);
@@ -2181,6 +2327,7 @@ context_parse_doctype_notation (ParserContext *context, char **line) {
 
 static void
 context_parse_doctype_entity (ParserContext *context, char **line) {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->doctype_state == DOCTYPE_STATE_INT) {
         g_assert (g_str_has_prefix(*line, "<!ENTITY"));
         (*line) += 8; context->colnum += 8;
@@ -2351,13 +2498,13 @@ context_parse_doctype_entity (ParserContext *context, char **line) {
             if (context->cur_text) {
                 char *value = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                axing_dtd_schema_add_parameter (context->parser->priv->doctype,
+                axing_dtd_schema_add_parameter (priv->doctype,
                                                 context->cur_qname,
                                                 value);
                 g_free (value);
             }
             else {
-                axing_dtd_schema_add_external_parameter (context->parser->priv->doctype,
+                axing_dtd_schema_add_external_parameter (priv->doctype,
                                                          context->cur_qname,
                                                          context->decl_public,
                                                          context->decl_system);
@@ -2367,20 +2514,20 @@ context_parse_doctype_entity (ParserContext *context, char **line) {
             if (context->cur_text) {
                 char *value = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                axing_dtd_schema_add_entity (context->parser->priv->doctype,
+                axing_dtd_schema_add_entity (priv->doctype,
                                              context->cur_qname,
                                              value);
                 g_free (value);
             }
             else if (context->decl_ndata) {
-                axing_dtd_schema_add_unparsed_entity (context->parser->priv->doctype,
+                axing_dtd_schema_add_unparsed_entity (priv->doctype,
                                                       context->cur_qname,
                                                       context->decl_public,
                                                       context->decl_system,
                                                       context->decl_ndata);
             }
             else {
-                axing_dtd_schema_add_external_entity (context->parser->priv->doctype,
+                axing_dtd_schema_add_external_entity (priv->doctype,
                                                       context->cur_qname,
                                                       context->decl_public,
                                                       context->decl_system);
@@ -2416,6 +2563,7 @@ static void
 context_parse_parameter (ParserContext  *context,
                          char          **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     const char *beg = *line + 1;
     char *entname = NULL;
     char *value = NULL;
@@ -2450,7 +2598,7 @@ context_parse_parameter (ParserContext  *context,
     entname = g_strndup (beg, *line - beg);
     (*line)++; colnum++;
 
-    value = axing_dtd_schema_get_parameter (context->parser->priv->doctype, entname);
+    value = axing_dtd_schema_get_parameter (priv->doctype, entname);
     if (value) {
         ParserContext *entctxt = context_new (context->parser);
         /* not duping these two, NULL them before free below */
@@ -2460,12 +2608,13 @@ context_parse_parameter (ParserContext  *context,
         entctxt->state = context->state;
         entctxt->init_state = context->state;
         entctxt->doctype_state = context->doctype_state;
-        entctxt->event_stack_root = entctxt->parser->priv->event_stack->len;
+        entctxt->xml_version = context->xml_version;
+        entctxt->event_stack_root = priv->event_stack->len;
         entctxt->cur_text = context->cur_text;
         context->cur_text = NULL;
 
         context_parse_data (entctxt, value);
-        if (entctxt->parser->priv->error == NULL) {
+        if (priv->error == NULL) {
             if (entctxt->state != context->state
                 || entctxt->doctype_state != context->doctype_state)
                 ERROR_SYNTAX(entctxt);
@@ -2491,6 +2640,7 @@ context_parse_parameter (ParserContext  *context,
 static void
 context_parse_cdata (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->state != PARSER_STATE_CDATA) {
         if (!g_str_has_prefix (*line, "<![CDATA[")) {
             ERROR_SYNTAX(context);
@@ -2504,9 +2654,9 @@ context_parse_cdata (ParserContext *context, char **line)
         if ((*line)[0] == ']' && (*line)[1] == ']' && (*line)[2] == '>') {
             (*line) += 3; context->colnum += 3;
 
-            context->parser->priv->event_content = g_string_free (context->cur_text, FALSE);
+            priv->event_content = g_string_free (context->cur_text, FALSE);
             context->cur_text = NULL;
-            context->parser->priv->event_type = AXING_STREAM_EVENT_CDATA;
+            priv->event_type = AXING_STREAM_EVENT_CDATA;
 
             axing_stream_emit_event (AXING_STREAM (context->parser));
             parser_clean_event_data (context->parser);
@@ -2523,6 +2673,7 @@ context_parse_cdata (ParserContext *context, char **line)
 static void
 context_parse_comment (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->state != PARSER_STATE_COMMENT) {
         if (!g_str_has_prefix (*line, "<!--")) {
             ERROR_SYNTAX(context);
@@ -2546,9 +2697,9 @@ context_parse_comment (ParserContext *context, char **line)
                 context->cur_text = NULL;
             }
             else {
-                context->parser->priv->event_content = g_string_free (context->cur_text, FALSE);
+                priv->event_content = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                context->parser->priv->event_type = AXING_STREAM_EVENT_COMMENT;
+                priv->event_type = AXING_STREAM_EVENT_COMMENT;
 
                 axing_stream_emit_event (AXING_STREAM (context->parser));
                 parser_clean_event_data (context->parser);
@@ -2566,12 +2717,13 @@ context_parse_comment (ParserContext *context, char **line)
 static void
 context_parse_instruction (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->state != PARSER_STATE_INSTRUCTION) {
         if (!g_str_has_prefix (*line, "<?")) {
             ERROR_SYNTAX(context);
         }
         (*line) += 2; context->colnum += 2;
-        XML_GET_NAME(line, context->parser->priv->event_qname, context);
+        XML_GET_NAME(line, priv->event_qname, context);
         if (!(XML_IS_SPACE(*line, context) || (*line)[0] == '\0' || (*line)[0] == '?'))
             ERROR_SYNTAX(context);
 
@@ -2596,9 +2748,9 @@ context_parse_instruction (ParserContext *context, char **line)
                 context->cur_text = NULL;
             }
             else {
-                context->parser->priv->event_content = g_string_free (context->cur_text, FALSE);
+                priv->event_content = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                context->parser->priv->event_type = AXING_STREAM_EVENT_INSTRUCTION;
+                priv->event_type = AXING_STREAM_EVENT_INSTRUCTION;
 
                 axing_stream_emit_event (AXING_STREAM (context->parser));
                 parser_clean_event_data (context->parser);
@@ -2616,6 +2768,7 @@ context_parse_instruction (ParserContext *context, char **line)
 static void
 context_parse_end_element (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     ParserStackFrame frame;
     const char *colon;
     if (context->state != PARSER_STATE_ENDELM) {
@@ -2623,7 +2776,7 @@ context_parse_end_element (ParserContext *context, char **line)
         context->node_linenum = context->linenum;
         context->node_colnum = context->colnum;
         (*line) += 2; context->colnum += 2;
-        XML_GET_NAME(line, context->parser->priv->event_qname, context);
+        XML_GET_NAME(line, priv->event_qname, context);
         if (!(XML_IS_SPACE(*line, context) || (*line)[0] == '\0' || (*line)[0] == '>'))
             ERROR_SYNTAX(context);
     }
@@ -2637,60 +2790,55 @@ context_parse_end_element (ParserContext *context, char **line)
     }
     (*line)++; context->colnum++;
 
-    colon = strchr (context->parser->priv->event_qname, ':');
+    colon = strchr (priv->event_qname, ':');
     if (colon != NULL) {
         gunichar cp;
         const char *localname;
         const char *namespace;
-        if (colon == context->parser->priv->event_qname) {
-            ERROR_NS_QNAME(context);
+        if (colon == priv->event_qname) {
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
         localname = colon + 1;
         if (localname[0] == '\0' || strchr (localname, ':')) {
-            ERROR_NS_QNAME(context);
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
         cp = g_utf8_get_char (localname);
         if (!XML_IS_NAME_START_CHAR(cp)) {
-            ERROR_NS_QNAME(context);
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
-        context->parser->priv->event_prefix = g_strndup (context->parser->priv->event_qname,
-                                                         colon - context->parser->priv->event_qname);
-        context->parser->priv->event_localname = g_strdup (localname);
-        namespace = namespace_map_get_namespace (AXING_NAMESPACE_MAP (context->parser),
-                                                 context->parser->priv->event_prefix);
+        priv->event_prefix = g_strndup (priv->event_qname, colon - priv->event_qname);
+        priv->event_localname = g_strdup (localname);
+        namespace = namespace_map_get_namespace (AXING_NAMESPACE_MAP (context->parser), priv->event_prefix);
         if (namespace == NULL) {
-            ERROR_NS_NOTFOUND(context);
+            ERROR_NS_NOTFOUND(context, priv->event_prefix);
         }
-        context->parser->priv->event_namespace = g_strdup (namespace);
+        priv->event_namespace = g_strdup (namespace);
     }
     else {
         const char *namespace = namespace_map_get_namespace (AXING_NAMESPACE_MAP (context->parser), "");
         if (namespace != NULL)
-            context->parser->priv->event_namespace = g_strdup (namespace);
+            priv->event_namespace = g_strdup (namespace);
     }
 
-    if (context->parser->priv->event_stack->len <= context->event_stack_root) {
+    if (priv->event_stack->len <= context->event_stack_root) {
         context->linenum = context->node_linenum;
         context->colnum = context->node_colnum;
         ERROR_EXTRACONTENT(context);
     }
-    frame = g_array_index (context->parser->priv->event_stack,
-                           ParserStackFrame,
-                           context->parser->priv->event_stack->len - 1);
-    g_array_remove_index (context->parser->priv->event_stack,
-                          context->parser->priv->event_stack->len - 1);
-    if (!g_str_equal (frame.qname, context->parser->priv->event_qname)) {
-        ERROR_WRONGEND(context);
+    frame = g_array_index (priv->event_stack, ParserStackFrame, priv->event_stack->len - 1);
+    g_array_remove_index (priv->event_stack, priv->event_stack->len - 1);
+    if (!g_str_equal (frame.qname, priv->event_qname)) {
+        ERROR_WRONGEND(context, priv->event_qname);
     }
     if (frame.nshash) {
         g_hash_table_destroy (frame.nshash);
     }
     g_free (frame.qname);
 
-    context->parser->priv->event_type = AXING_STREAM_EVENT_END_ELEMENT;
+    priv->event_type = AXING_STREAM_EVENT_END_ELEMENT;
     axing_stream_emit_event (AXING_STREAM (context->parser));
 
-    if (context->parser->priv->event_stack->len == context->event_stack_root)
+    if (priv->event_stack->len == context->event_stack_root)
         context->state = context->init_state;
     else
         context->state = PARSER_STATE_TEXT;
@@ -2736,6 +2884,7 @@ context_parse_start_element (ParserContext *context, char **line)
 static void
 context_parse_attrs (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->state == PARSER_STATE_STELM_BASE) {
         EAT_SPACES (*line, *line, -1, context);
         if ((*line)[0] == '>') {
@@ -2869,7 +3018,7 @@ context_parse_attrs (ParserContext *context, char **line)
                     g_string_append_len (context->cur_text, *line, cur - *line);
                 context_parse_entity (context, &cur);
                 *line = cur;
-                if (context->parser->priv->error)
+                if (priv->error)
                     goto error;
                 continue;
             }
@@ -2996,6 +3145,7 @@ context_parse_entity (ParserContext *context, char **line)
 static void
 context_process_entity (ParserContext *context, const char *entname, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     ParserContext *parent;
     char *value=NULL, *system=NULL, *public=NULL, *ndata=NULL;
 
@@ -3005,7 +3155,7 @@ context_process_entity (ParserContext *context, const char *entname, char **line
         }
     }
 
-    if (axing_dtd_schema_get_entity_full (context->parser->priv->doctype, entname,
+    if (axing_dtd_schema_get_entity_full (priv->doctype, entname,
                                           &value, &public, &system, &ndata)) {
         if (value) {
             ParserContext *entctxt = context_new (context->parser);
@@ -3016,12 +3166,13 @@ context_process_entity (ParserContext *context, const char *entname, char **line
             entctxt->showname = g_strdup_printf ("%s(&%s;)", entctxt->basename, entname);
             entctxt->state = context->state;
             entctxt->init_state = context->state;
-            entctxt->event_stack_root = entctxt->parser->priv->event_stack->len;
+            entctxt->xml_version = context->xml_version;
+            entctxt->event_stack_root = priv->event_stack->len;
             entctxt->cur_text = context->cur_text;
             context->cur_text = NULL;
 
             context_parse_data (entctxt, value);
-            if (entctxt->parser->priv->error == NULL)
+            if (priv->error == NULL)
                 context_check_end (entctxt);
 
             context->state = entctxt->state;
@@ -3041,24 +3192,25 @@ context_process_entity (ParserContext *context, const char *entname, char **line
                 ERROR_ENTITY(context);
             }
 
-            if (context->parser->priv->resolver)
-                resolver = g_object_ref (context->parser->priv->resolver);
+            if (priv->resolver)
+                resolver = g_object_ref (priv->resolver);
             else
                 resolver = axing_resolver_get_default ();
 
-            if (context->parser->priv->async) {
+            if (priv->async) {
                 ParserContext *entctxt;
                 entctxt = context_new (context->parser);
                 entctxt->parent = context;
                 entctxt->entname = g_strdup (entname);
                 entctxt->state = PARSER_STATE_TEXTDECL;
                 entctxt->init_state = context->state;
-                entctxt->event_stack_root = entctxt->parser->priv->event_stack->len;
+                entctxt->xml_version = context->xml_version;
+                entctxt->event_stack_root = priv->event_stack->len;
                 entctxt->cur_text = context->cur_text;
                 context->cur_text = NULL;
                 axing_resolver_resolve_async (resolver, context->resource,
                                               NULL, system, public, "xml:entity",
-                                              context->parser->priv->cancellable,
+                                              priv->cancellable,
                                               (GAsyncReadyCallback) context_process_entity_resolved,
                                               entctxt);
                 context->pause_line = g_strdup (*line);
@@ -3070,9 +3222,9 @@ context_process_entity (ParserContext *context, const char *entname, char **line
                 AxingResource *resource;
                 resource = axing_resolver_resolve (resolver, context->resource,
                                                    NULL, system, public, "xml:entity",
-                                                   context->parser->priv->cancellable,
-                                                   &(context->parser->priv->error));
-                if (context->parser->priv->error) {
+                                                   priv->cancellable,
+                                                   &priv->error);
+                if (priv->error) {
                     g_object_unref (resolver);
                     goto error;
                 }
@@ -3084,7 +3236,8 @@ context_process_entity (ParserContext *context, const char *entname, char **line
                 entctxt->entname = g_strdup (entname);
                 entctxt->state = PARSER_STATE_TEXTDECL;
                 entctxt->init_state = context->state;
-                entctxt->event_stack_root = entctxt->parser->priv->event_stack->len;
+                entctxt->xml_version = context->xml_version;
+                entctxt->event_stack_root = priv->event_stack->len;
                 entctxt->cur_text = context->cur_text;
                 context->cur_text = NULL;
 
@@ -3110,18 +3263,18 @@ context_process_entity_resolved (AxingResolver *resolver,
                                  GAsyncResult  *result,
                                  ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     AxingResource *resource;
 
-    resource = axing_resolver_resolve_finish (resolver, result,
-                                              &(context->parser->priv->error));
-    if (context->parser->priv->error)
+    resource = axing_resolver_resolve_finish (resolver, result, &priv->error);
+    if (priv->error)
         goto error;
 
     context->resource = resource;
     context->basename = resource_get_basename (resource);
 
     axing_resource_read_async (context->resource,
-                               context->parser->priv->cancellable,
+                               priv->cancellable,
                                (GAsyncReadyCallback) context_resource_read_cb,
                                context);
  error:
@@ -3146,17 +3299,18 @@ context_process_entity_finish (ParserContext *context)
 static void
 context_parse_text (ParserContext *context, char **line)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     char *cur = *line;
     while (cur[0] != '\0') {
         if (cur[0] == '<') {
             if (context->cur_text) {
-                g_free (context->parser->priv->event_content);
+                g_free (priv->event_content);
                 if (cur != *line)
                     g_string_append_len (context->cur_text, *line, cur - *line);
                 *line = cur;
-                context->parser->priv->event_content = g_string_free (context->cur_text, FALSE);
+                priv->event_content = g_string_free (context->cur_text, FALSE);
                 context->cur_text = NULL;
-                context->parser->priv->event_type = AXING_STREAM_EVENT_CONTENT;
+                priv->event_type = AXING_STREAM_EVENT_CONTENT;
 
                 axing_stream_emit_event (AXING_STREAM (context->parser));
                 parser_clean_event_data (context->parser);
@@ -3170,7 +3324,7 @@ context_parse_text (ParserContext *context, char **line)
                 g_string_append_len (context->cur_text, *line, cur - *line);
             context_parse_entity (context, &cur);
             *line = cur;
-            if (context->parser->priv->error)
+            if (priv->error)
                 goto error;
             continue;
         }
@@ -3189,48 +3343,48 @@ context_parse_text (ParserContext *context, char **line)
 static void
 context_trigger_start_element (ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     ParserStackFrame frame;
     const char *colon;
 
-    g_free (context->parser->priv->event_qname);
-    context->parser->priv->event_qname = context->cur_qname;
+    g_free (priv->event_qname);
+    priv->event_qname = context->cur_qname;
     context->cur_qname = NULL;
 
-    frame.qname = g_strdup (context->parser->priv->event_qname);
+    frame.qname = g_strdup (priv->event_qname);
     frame.nshash = context->cur_nshash;
     context->cur_nshash = NULL;
-    g_array_append_val (context->parser->priv->event_stack, frame);
+    g_array_append_val (priv->event_stack, frame);
 
-    colon = strchr (context->parser->priv->event_qname, ':');
+    colon = strchr (priv->event_qname, ':');
     if (colon != NULL) {
         gunichar cp;
         const char *localname;
         const char *namespace;
-        if (colon == context->parser->priv->event_qname) {
-            ERROR_NS_QNAME(context);
+        if (colon == priv->event_qname) {
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
         localname = colon + 1;
         if (localname[0] == '\0' || strchr (localname, ':')) {
-            ERROR_NS_QNAME(context);
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
         cp = g_utf8_get_char (localname);
         if (!XML_IS_NAME_START_CHAR(cp)) {
-            ERROR_NS_QNAME(context);
+            ERROR_NS_QNAME(context, priv->event_qname);
         }
-        context->parser->priv->event_prefix = g_strndup (context->parser->priv->event_qname,
-                                                         colon - context->parser->priv->event_qname);
-        context->parser->priv->event_localname = g_strdup (localname);
+        priv->event_prefix = g_strndup (priv->event_qname, colon - priv->event_qname);
+        priv->event_localname = g_strdup (localname);
         namespace = namespace_map_get_namespace (AXING_NAMESPACE_MAP (context->parser),
-                                                 context->parser->priv->event_prefix);
+                                                 priv->event_prefix);
         if (namespace == NULL) {
-            ERROR_NS_NOTFOUND(context);
+            ERROR_NS_NOTFOUND(context, priv->event_prefix);
         }
-        context->parser->priv->event_namespace = g_strdup (namespace);
+        priv->event_namespace = g_strdup (namespace);
     }
     else {
         const char *namespace = namespace_map_get_namespace (AXING_NAMESPACE_MAP (context->parser), "");
         if (namespace != NULL)
-            context->parser->priv->event_namespace = g_strdup (namespace);
+            priv->event_namespace = g_strdup (namespace);
     }
 
     if (context->cur_attrs) {
@@ -3239,8 +3393,8 @@ context_trigger_start_element (ParserContext *context)
         guint num = g_hash_table_size (context->cur_attrs);
         guint cur;
 
-        context->parser->priv->event_attrkeys = g_new0 (char *, num + 1);
-        context->parser->priv->event_attrvals = g_new0 (AttributeData *, num + 1);
+        priv->event_attrkeys = g_new0 (char *, num + 1);
+        priv->event_attrvals = g_new0 (AttributeData *, num + 1);
 
         cur = 0;
         /* We drop from the hash at each iteration, stealing the key and
@@ -3279,18 +3433,16 @@ context_trigger_start_element (ParserContext *context)
                 }
                 data->namespace = g_strdup (namespace);
                 for (pre = 0; pre < cur; pre++) {
-                    if (context->parser->priv->event_attrvals[pre]->namespace &&
-                        g_str_equal (context->parser->priv->event_attrvals[pre]->namespace,
-                                     data->namespace) &&
-                        g_str_equal (context->parser->priv->event_attrvals[pre]->localname,
-                                     data->localname)) {
+                    if (priv->event_attrvals[pre]->namespace &&
+                        g_str_equal (priv->event_attrvals[pre]->namespace, data->namespace) &&
+                        g_str_equal (priv->event_attrvals[pre]->localname, data->localname)) {
                         ERROR_NS_DUPATTR(context, data);
                     }
                 }
             }
 
-            context->parser->priv->event_attrkeys[cur] = qname;
-            context->parser->priv->event_attrvals[cur] = data;
+            priv->event_attrkeys[cur] = qname;
+            priv->event_attrvals[cur] = data;
             cur++;
             g_hash_table_steal (context->cur_attrs, key);
         }
@@ -3298,7 +3450,7 @@ context_trigger_start_element (ParserContext *context)
         context->cur_attrs = NULL;
     }
 
-    context->parser->priv->event_type = AXING_STREAM_EVENT_START_ELEMENT;
+    priv->event_type = AXING_STREAM_EVENT_START_ELEMENT;
     axing_stream_emit_event (AXING_STREAM (context->parser));
 
     if (context->empty) {
@@ -3306,16 +3458,15 @@ context_trigger_start_element (ParserContext *context)
             g_hash_table_destroy (frame.nshash);
         }
         g_free (frame.qname);
-        g_array_remove_index (context->parser->priv->event_stack,
-                              context->parser->priv->event_stack->len - 1);
-        context->parser->priv->event_type = AXING_STREAM_EVENT_END_ELEMENT;
+        g_array_remove_index (priv->event_stack, priv->event_stack->len - 1);
+        priv->event_type = AXING_STREAM_EVENT_END_ELEMENT;
         axing_stream_emit_event (AXING_STREAM (context->parser));
     }
 
  error:
     parser_clean_event_data (context->parser);
     if (context->empty &&
-        (context->parser->priv->event_stack->len == context->event_stack_root)) {
+        (priv->event_stack->len == context->event_stack_root)) {
         context->state = context->init_state;
         if (context->state == PARSER_STATE_PROLOG)
             context->state = PARSER_STATE_EPILOG;
@@ -3329,10 +3480,11 @@ context_trigger_start_element (ParserContext *context)
 static void
 context_complete (ParserContext *context)
 {
+    AxingXmlParserPrivate *priv = axing_xml_parser_get_instance_private (context->parser);
     if (context->parent)
         context_process_entity_finish (context);
     else
-        g_simple_async_result_complete (context->parser->priv->result);
+        g_simple_async_result_complete (priv->result);
 }
 
 static char *

--- a/axing-xml-parser.h
+++ b/axing-xml-parser.h
@@ -31,25 +31,10 @@
 
 G_BEGIN_DECLS
 
-#define AXING_TYPE_XML_PARSER            (axing_xml_parser_get_type ())
-#define AXING_XML_PARSER(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), AXING_TYPE_XML_PARSER, AxingXmlParser))
-#define AXING_XML_PARSER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), AXING_TYPE_XML_PARSER, AxingXmlParserClass))
-#define AXING_IS_XML_PARSER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), AXING_TYPE_XML_PARSER))
-#define AXING_IS_XML_PARSER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), AXING_TYPE_XML_PARSER))
-#define AXING_XML_PARSER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), AXING_TYPE_XML_PARSER, AxingXmlParserClass))
+#define AXING_TYPE_XML_PARSER   (axing_xml_parser_get_type ())
+#define AXING_XML_PARSER_ERROR  (axing_xml_parser_error_quark ())
 
-#define AXING_XML_PARSER_ERROR axing_xml_parser_error_quark()
-
-typedef struct _AxingXmlParser        AxingXmlParser;
-typedef struct _AxingXmlParserPrivate AxingXmlParserPrivate;
-typedef struct _AxingXmlParserClass   AxingXmlParserClass;
-
-struct _AxingXmlParser {
-    AxingStream parent;
-
-    /*< private >*/
-    AxingXmlParserPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE (AxingXmlParser, axing_xml_parser, AXING, XML_PARSER, AxingStream)
 
 struct _AxingXmlParserClass {
     AxingStreamClass parent_class;
@@ -78,7 +63,6 @@ typedef enum {
     AXING_XML_PARSER_ERROR_OTHER
 } AxingXmlParserError;
 
-GType             axing_xml_parser_get_type        (void);
 GQuark            axing_xml_parser_error_quark     (void);
 
 AxingXmlParser *  axing_xml_parser_new             (AxingResource        *resource,


### PR DESCRIPTION
This is the last round of changes to make Axing use the current best practices for GObject:
- instance private data via pointer arithmetic instead of dereference
- macro-ified headers to cut down the boilerplate
- moderately adequate compiler warnings (could be improved)

I also ended up removing some dead code.

In theory we could do with a pass of `g_auto`, `g_autoptr`, and `g_autofree` to reduce the code in the error handling cases. There's also the port from `GSimpleAsyncResult` to `GTask`, but those are two large, non-mechanical refactorings.
